### PR TITLE
Support syncing all blocks & dumping the balance book

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,4 +3,5 @@ module.exports = {
   ...require('./lib/chain'),
   ...require('./lib/key'),
   ...require('./lib/session'),
+  ...require('./lib/stats'),
 }

--- a/lib/chain.js
+++ b/lib/chain.js
@@ -4,14 +4,15 @@ class Chain {
   /**
    *
    * @param {Session} session
+   * @param {boolean} sync_all
    * @param {number} interval
    */
-  constructor(session) {
+  constructor(session, sync_all = false, interval = 1000) {
     this.index_to_block = new Map();
     this.hash_to_block = new Map();
     this.hash_to_transaction = new Map();
     this.active = true;
-    this.update_loop(session, 1000);
+    this.update_loop(session, sync_all, interval);
   }
 
   /**
@@ -30,8 +31,11 @@ class Chain {
     this.active = false;
   }
 
-  async update_loop(session, interval) {
-    await this.get_block(session, await my_current_block_id(session));
+  async update_loop(session, sync_all, interval) {
+    await this.get_block(
+      session,
+      await (sync_all ? my_genesis_block_id : my_current_block_id)(session)
+    );
 
     while (this.active) {
       let block_id = await my_current_block_id(session);
@@ -63,6 +67,10 @@ class Chain {
 }
 
 exports.Chain = Chain;
+
+async function my_genesis_block_id(session) {
+  return (await my_status(session)).genesis_block_identifier;
+}
 
 async function my_current_block_id(session) {
   return (await my_status(session)).current_block_identifier;

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -1,0 +1,36 @@
+const { Chain } = require("./chain.js");
+
+/**
+ *
+ * @param {Session} session
+ * @param {number} timeout
+ */
+
+async function stats(session, timeout = 10000) {
+  const chain = new Chain(session, true, 1000);
+  await new Promise((res) => setTimeout(res, timeout));
+  chain.close();
+
+  const addr_to_balance = new Map();
+  for (const t of chain.hash_to_transaction.values()) {
+    for (const op of t.operations) {
+      if (op.status === "COMPLETED") {
+        const addr = op.account.address;
+        const balance =
+          (addr_to_balance.has(addr) ? addr_to_balance.get(addr) : 0n) +
+          BigInt(op.amount.value);
+        if (balance === 0n) {
+          addr_to_balance.delete(addr);
+        } else {
+          addr_to_balance.set(addr, balance);
+        }
+      } else {
+        throw new Error(`Unsupported transaction ${t}`);
+      }
+    }
+  }
+
+  return addr_to_balance;
+}
+
+exports.stats = stats;


### PR DESCRIPTION
As a part of helping the upgrade of the exchanges subnet, this PR adds the support for:

* Sync all blocks instead of only recent blocks
* Traverse all transactions and dump the balance book

These are not a part of the public API yet, so they're not covered on `README`. Won't break the existing user code.