### PR TITLE
DER-encode the public key when deriving principal ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ const {
   hex_decode,
   hex_encode,
   key_new,
-  key_to_address,
+  key_to_pub_key,
+  pub_key_to_address,
   Chain,
   Session,
 } = require("@dfinity/rosetta-client");
@@ -30,7 +31,7 @@ const key = key_new();
 //
 // 从私钥生成公开的账户地址。账户地址类型为 Buffer，用 hex_encode() 可以将其编码
 // 为在请求的 address 一栏中所用的地址字符串。
-const address = key_to_address(key);
+const address = pub_key_to_address(key_to_pub_key(key));
 console.log(hex_encode(address));
 
 // A Session is a subclass of RosettaClient, and you can use methods of

--- a/lib/key.js
+++ b/lib/key.js
@@ -139,21 +139,57 @@ function sha224(buf) {
   return h.digest();
 }
 
+const der_header = Buffer.from([
+  0x30,
+  0x2a,
+  0x30,
+  0x05,
+  0x06,
+  0x03,
+  0x2b,
+  0x65,
+  0x70,
+  0x03,
+  0x21,
+  0x00,
+]);
+
 /**
- * Given a private key, generate the account address.
- * @param {Buffer} priv_key
+ *
+ * @param {Buffer} pub_key
+ */
+function pub_key_to_der(pub_key) {
+  let buf = Buffer.allocUnsafe(12 + 32);
+  der_header.copy(buf, 0);
+  pub_key.copy(buf, 12);
+  return buf;
+}
+
+/**
+ *
+ * @param {Buffer} buf
+ */
+function pub_key_from_der(buf) {
+  return Buffer.from(
+    forge.asn1.fromDer(forge.util.createBuffer(buf)).value[1].value,
+    "binary"
+  ).subarray(1);
+}
+
+/**
+ * Given a public key, generate the account address.
+ * @param {Buffer} pub_key
  * @returns {Buffer}
  */
-function key_to_address(priv_key) {
-  const pub_key = key_to_pub_key(priv_key);
-  const pub_key_hash = sha224(pub_key);
-  const principal_id_buf = Buffer.allocUnsafe(pub_key_hash.length + 1);
-  pub_key_hash.copy(principal_id_buf, 0);
-  principal_id_buf.writeUInt8(TYPE_SELF_AUTH, pub_key_hash.length);
+function pub_key_to_address(pub_key) {
+  const pub_key_der_hash = sha224(pub_key_to_der(pub_key));
+  const principal_id_buf = Buffer.allocUnsafe(pub_key_der_hash.length + 1);
+  pub_key_der_hash.copy(principal_id_buf, 0);
+  principal_id_buf.writeUInt8(TYPE_SELF_AUTH, pub_key_der_hash.length);
   return principal_id_buf;
 }
 
-exports.key_to_address = key_to_address;
+exports.pub_key_to_address = pub_key_to_address;
 
 /**
  * Given an account address, generate its textual representation.

--- a/lib/session.js
+++ b/lib/session.js
@@ -4,7 +4,7 @@ const {
   hex_encode,
   key_sign,
   key_to_pub_key,
-  key_to_address,
+  pub_key_to_address,
 } = require("./key.js");
 
 class Session extends RosettaClient {
@@ -62,7 +62,7 @@ class Session extends RosettaClient {
         {
           operation_identifier: { index: 0 },
           type: "TRANSACTION",
-          account: { address: hex_encode(key_to_address(src_key)) },
+          account: { address: hex_encode(pub_key_to_address(key_to_pub_key(src_key))) },
           amount: {
             value: `${-count - (await this.suggested_fee)}`,
             currency: currency,


### PR DESCRIPTION
This is required since https://github.com/dfinity-lab/dfinity/commit/402311a8a82e807bd9c78c5ea87096f71bcb984e. We should do a new release after the test net update, then deprecate `0.0.1`.