### PR TITLE
Misc fixes dealing with upstream breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ chain.close();
 // 且会执行网络调用。我们支持在转账时，仅在完全隔离的环境中使用私钥，用例如下。
 
 const payloads_result = await session.transfer_pre_combine(
-  source_address,
+  source_pub_key,
   destination_address,
   123n
 );

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ const {
   address_to_hex,
   Chain,
   Session,
+  transaction_hash,
   transfer_combine,
 } = require("@dfinity/rosetta-client");
 
@@ -135,6 +136,16 @@ const payloads_result = await session.transfer_pre_combine(
 const combine_result = transfer_combine(source_private_key, payloads_result);
 
 const submit_result = await session.transfer_post_combine(combine_result);
+
+// There are two ways to obtain a transaction hash. One is reading the result of
+// /construction/submit call, another is using transaction_hash() to calculate
+// it locally.
+//
+// 有两种计算 transaction hash 的方法。第一种是从 /construction/submit 调用的结
+// 果读取，第二种是调用 transaction_hash() 函数离线计算。
+
+const tx_hash = transaction_hash(payloads_result);
+assert(hex_encode(tx_hash) === submit_result.transaction_identifier.hash);
 ```
 
 [rosetta-ts-client]: https://github.com/lunarhq/rosetta-ts-client

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ helper functions to derive keys/accounts and perform transfers.
 
 ```javascript
 const {
-  hex_decode,
-  hex_encode,
   key_new,
   key_to_pub_key,
   pub_key_to_address,
+  address_from_hex,
+  address_to_hex,
   Chain,
   Session,
   transfer_combine,
@@ -33,16 +33,16 @@ let key = key_new();
 // 使用 32 字节的随机数种子生成私钥。我们推荐使用本方式生成私钥，因为可以存储随
 // 机数种子，且该种子可在其他语言/框架中重新构造相同的密钥。
 const seed = Buffer.allocUnsafe(32);
-key = key_new({seed: seed});
+key = key_new({ seed: seed });
 
 // Generate the public account address from a private key. The result is a
-// Buffer. Use hex_encode() to generate the string representation used in the
-// address field of requests.
+// Buffer. Use address_to_hex() to generate the string representation used in
+// the address field of requests.
 //
-// 从私钥生成公开的账户地址。账户地址类型为 Buffer，用 hex_encode() 可以将其编码
-// 为在请求的 address 一栏中所用的地址字符串。
+// 从私钥生成公开的账户地址。账户地址类型为 Buffer，用 address_to_hex() 可以将其
+// 编码为在请求的 address 一栏中所用的地址字符串。
 const address = pub_key_to_address(key_to_pub_key(key));
-console.log(hex_encode(address));
+console.log(address_to_hex(address));
 
 // A Session is a subclass of RosettaClient, and you can use methods of
 // RosettaClient to invoke the Rosetta API.
@@ -89,7 +89,7 @@ console.log(await session.suggested_fee);
 // 划入账户将收到参数指定的转账数额。划出账户将额外扣除交易费用。
 const submit_result = await session.transfer(
   key,
-  hex_decode(destination_address_hex_string),
+  address_from_hex(destination_address_hex_string),
   123n
 );
 console.log(submit_result);

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 // Use specific export syntax to allow bundlers and IDEs to properly load dependencies.
 module.exports = {
-  ...require('./lib/chain'),
-  ...require('./lib/construction_combine'),
-  ...require('./lib/key'),
-  ...require('./lib/session'),
-  ...require('./lib/stats'),
-}
+  ...require("./lib/chain"),
+  ...require("./lib/construction_combine"),
+  ...require("./lib/key"),
+  ...require("./lib/session"),
+  ...require("./lib/stats"),
+  ...require("./lib/transaction_hash"),
+};

--- a/lib/cbor.js
+++ b/lib/cbor.js
@@ -1,0 +1,26 @@
+const assert = require("assert").strict;
+const cbor = require("cbor");
+
+/**
+ *
+ * @param {Buffer} buf
+ * @returns {any}
+ */
+function cbor_decode(buf) {
+  const res = cbor.decodeAllSync(buf);
+  assert(res.length === 1);
+  return res[0];
+}
+
+exports.cbor_decode = cbor_decode;
+
+/**
+ *
+ * @param {any} value
+ * @returns {Buffer}
+ */
+function cbor_encode(value) {
+  return cbor.encodeOne(value, { collapseBigIntegers: true });
+}
+
+exports.cbor_encode = cbor_encode;

--- a/lib/construction_combine.js
+++ b/lib/construction_combine.js
@@ -1,6 +1,7 @@
 const assert = require("assert").strict;
-const crypto = require("crypto");
 const cbor = require("cbor");
+const { cbor_decode, cbor_encode } = require("./cbor.js");
+const { sha256 } = require("./hash.js");
 const {
   hex_decode,
   hex_encode,
@@ -80,26 +81,6 @@ function combine(req) {
   const signed_transaction = hex_encode(cbor_encode(envelopes));
 
   return { signed_transaction: signed_transaction };
-}
-
-/**
- *
- * @param {Buffer} buf
- * @returns {any}
- */
-function cbor_decode(buf) {
-  const res = cbor.decodeAllSync(buf);
-  assert(res.length === 1);
-  return res[0];
-}
-
-/**
- *
- * @param {any} value
- * @returns {Buffer}
- */
-function cbor_encode(value) {
-  return cbor.encodeOne(value, { collapseBigIntegers: true });
 }
 
 /**
@@ -257,15 +238,4 @@ function hash_U64(n) {
  */
 function hash_array(elements) {
   return sha256(elements.map(hash_val));
-}
-
-/**
- *
- * @param {Array<Buffer>} chunks
- * @returns {Buffer}
- */
-function sha256(chunks) {
-  const hasher = crypto.createHash("sha256");
-  chunks.forEach((chunk) => hasher.update(chunk));
-  return hasher.digest();
 }

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,0 +1,27 @@
+const crypto = require("crypto");
+
+/**
+ *
+ * @param {Array<Buffer>} chunks
+ * @returns {Buffer}
+ */
+function sha256(chunks) {
+  const hasher = crypto.createHash("sha256");
+  chunks.forEach((chunk) => hasher.update(chunk));
+  return hasher.digest();
+}
+
+exports.sha256 = sha256;
+
+/**
+ *
+ * @param {Array<Buffer>} chunks
+ * @returns {Buffer}
+ */
+function sha224(chunks) {
+  const h = crypto.createHash("sha224");
+  chunks.forEach((chunk) => h.update(chunk));
+  return h.digest();
+}
+
+exports.sha224 = sha224;

--- a/lib/key.js
+++ b/lib/key.js
@@ -1,8 +1,8 @@
 const assert = require("assert").strict;
 const crc = require("crc");
-const crypto = require("crypto");
 const forge = require("node-forge");
 const rfc4648 = require("rfc4648");
+const { sha224 } = require("./hash.js");
 
 /**
  * The principal ids we create are always self-authenticating ones.
@@ -131,17 +131,6 @@ function key_sign(priv_key, msg) {
 
 exports.key_sign = key_sign;
 
-/**
- *
- * @param {Array<Buffer>} chunks
- * @returns {Buffer}
- */
-function sha224(chunks) {
-  const h = crypto.createHash("sha224");
-  chunks.forEach((chunk) => h.update(chunk));
-  return h.digest();
-}
-
 const der_header = Buffer.from([
   0x30,
   0x2a,
@@ -203,6 +192,8 @@ function pub_key_to_principal_id(pub_key) {
 function principal_id_to_address(pid) {
   return sha224([pid]);
 }
+
+exports.principal_id_to_address = principal_id_to_address;
 
 /**
  * Given a public key, generate the account address.

--- a/lib/key.js
+++ b/lib/key.js
@@ -184,13 +184,16 @@ function pub_key_to_principal_id(pub_key) {
   return principal_id_buf;
 }
 
+const SUB_ACCOUNT_ZERO = Buffer.alloc(32);
+const ACCOUNT_DOMAIN_SEPERATOR = Buffer.from("\x0Aaccount-id");
+
 /**
  *
  * @param {Buffer} pid
  * @returns {Buffer}
  */
 function principal_id_to_address(pid) {
-  return sha224([pid]);
+  return sha224([ACCOUNT_DOMAIN_SEPERATOR, pid, SUB_ACCOUNT_ZERO]);
 }
 
 exports.principal_id_to_address = principal_id_to_address;

--- a/lib/key.js
+++ b/lib/key.js
@@ -1,4 +1,4 @@
-const assert = require('assert').strict;
+const assert = require("assert").strict;
 const crc = require("crc");
 const crypto = require("crypto");
 const forge = require("node-forge");
@@ -133,12 +133,12 @@ exports.key_sign = key_sign;
 
 /**
  *
- * @param {Buffer} buf
+ * @param {Array<Buffer>} chunks
  * @returns {Buffer}
  */
-function sha224(buf) {
+function sha224(chunks) {
   const h = crypto.createHash("sha224");
-  h.update(buf);
+  chunks.forEach((chunk) => h.update(chunk));
   return h.digest();
 }
 
@@ -162,11 +162,13 @@ const der_header = Buffer.from([
  * @param {Buffer} pub_key
  */
 function pub_key_to_der(pub_key) {
+  assert(pub_key.byteLength === 32);
   let buf = Buffer.allocUnsafe(12 + 32);
   der_header.copy(buf, 0);
   pub_key.copy(buf, 12);
   return buf;
 }
+
 exports.pub_key_to_der = pub_key_to_der;
 
 /**
@@ -181,19 +183,62 @@ function pub_key_from_der(buf) {
 }
 
 /**
- * Given a public key, generate the account address.
+ *
  * @param {Buffer} pub_key
  * @returns {Buffer}
  */
-function pub_key_to_address(pub_key) {
-  const pub_key_der_hash = sha224(pub_key_to_der(pub_key));
+function pub_key_to_principal_id(pub_key) {
+  const pub_key_der_hash = sha224([pub_key_to_der(pub_key)]);
   const principal_id_buf = Buffer.allocUnsafe(pub_key_der_hash.length + 1);
   pub_key_der_hash.copy(principal_id_buf, 0);
   principal_id_buf.writeUInt8(TYPE_SELF_AUTH, pub_key_der_hash.length);
   return principal_id_buf;
 }
 
+/**
+ *
+ * @param {Buffer} pid
+ * @returns {Buffer}
+ */
+function principal_id_to_address(pid) {
+  return sha224([pid]);
+}
+
+/**
+ * Given a public key, generate the account address.
+ * @param {Buffer} pub_key
+ * @returns {Buffer}
+ */
+function pub_key_to_address(pub_key) {
+  assert(pub_key.byteLength === 32);
+  return principal_id_to_address(pub_key_to_principal_id(pub_key));
+}
+
 exports.pub_key_to_address = pub_key_to_address;
+
+/**
+ *
+ * @param {string} hex_str
+ * @returns {Buffer}
+ */
+function address_from_hex(hex_str) {
+  const buf = hex_decode(hex_str);
+  assert(buf.byteLength === 32);
+  return crc32_del(buf);
+}
+
+exports.address_from_hex = address_from_hex;
+
+/**
+ *
+ * @param {Buffer} addr_buf
+ * @returns {string}
+ */
+function address_to_hex(addr_buf) {
+  return hex_encode(crc32_add(addr_buf));
+}
+
+exports.address_to_hex = address_to_hex;
 
 /**
  * Given an account address, generate its textual representation.
@@ -204,8 +249,6 @@ function principal_id_encode(buf) {
   return base32_encode(crc32_add(buf));
 }
 
-exports.principal_id_encode = principal_id_encode;
-
 /**
  * Decode the textual representation of an account address.
  * @param {string} s
@@ -214,5 +257,3 @@ exports.principal_id_encode = principal_id_encode;
 function principal_id_decode(s) {
   return crc32_del(base32_decode(s));
 }
-
-exports.principal_id_decode = principal_id_decode;

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,3 +1,4 @@
+const assert = require("assert").strict;
 const { RosettaClient } = require("@lunarhq/rosetta-ts-client");
 const {
   key_to_pub_key,
@@ -6,6 +7,7 @@ const {
   hex_encode,
 } = require("./key.js");
 const { transfer_combine } = require("./construction_combine.js");
+const { transaction_hash } = require("./transaction_hash.js");
 
 class Session extends RosettaClient {
   /**
@@ -129,7 +131,14 @@ class Session extends RosettaClient {
 
     const combine_res = transfer_combine(src_key, payloads_res);
 
-    return this.transfer_post_combine(combine_res);
+    const submit_res = await this.transfer_post_combine(combine_res);
+
+    assert(
+      hex_encode(transaction_hash(payloads_res)) ===
+        submit_res.transaction_identifier.hash
+    );
+
+    return submit_res;
   }
 }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,5 +1,10 @@
 const { RosettaClient } = require("@lunarhq/rosetta-ts-client");
-const { hex_encode, key_to_pub_key, pub_key_to_address } = require("./key.js");
+const {
+  key_to_pub_key,
+  pub_key_to_address,
+  address_to_hex,
+  hex_encode,
+} = require("./key.js");
 const { transfer_combine } = require("./construction_combine.js");
 
 class Session extends RosettaClient {
@@ -38,17 +43,17 @@ class Session extends RosettaClient {
 
   /**
    *
-   * @param {Buffer} src_addr
+   * @param {Buffer} src_pub_key
    * @param {Buffer} dest_addr
    * @param {BigInt} count
    * @returns {Promise<import("@lunarhq/rosetta-ts-client").ConstructionPayloadsResponse>}
    */
-  async transfer_pre_combine(src_addr, dest_addr, count) {
+  async transfer_pre_combine(src_pub_key, dest_addr, count) {
     const net_id = await this.network_identifier;
     const currency = await this.currency;
 
     const src_account = {
-      address: hex_encode(src_addr),
+      address: address_to_hex(pub_key_to_address(src_pub_key)),
     };
 
     return this.payloads({
@@ -67,7 +72,7 @@ class Session extends RosettaClient {
           operation_identifier: { index: 1 },
           type: "TRANSACTION",
           account: {
-            address: hex_encode(dest_addr),
+            address: address_to_hex(dest_addr),
           },
           amount: {
             value: `${count}`,
@@ -85,6 +90,12 @@ class Session extends RosettaClient {
         },
       ],
       metadata: (await this.metadata({ network_identifier: net_id })).metadata,
+      public_keys: [
+        {
+          hex_bytes: hex_encode(src_pub_key),
+          curve_type: "edwards25519",
+        },
+      ],
     });
   }
 
@@ -111,7 +122,7 @@ class Session extends RosettaClient {
    */
   async transfer(src_key, dest_addr, count) {
     const payloads_res = await this.transfer_pre_combine(
-      pub_key_to_address(key_to_pub_key(src_key)),
+      key_to_pub_key(src_key),
       dest_addr,
       count
     );

--- a/lib/transaction_hash.js
+++ b/lib/transaction_hash.js
@@ -1,0 +1,88 @@
+const assert = require("assert").strict;
+const IDL = require("@dfinity/agent").IDL;
+const { cbor_decode, cbor_encode } = require("./cbor.js");
+const { sha256 } = require("./hash.js");
+const {
+  address_to_hex,
+  hex_decode,
+  principal_id_to_address,
+} = require("./key.js");
+
+const ICPTsType = IDL.Record({ doms: IDL.Nat64 });
+
+const MemoType = IDL.Nat64;
+
+const AccountIdentifierType = IDL.Text;
+
+const SubAccountType = IDL.Vec(IDL.Nat8);
+
+const SendArgsType = IDL.Record({
+  memo: MemoType,
+  amount: ICPTsType,
+  fee: ICPTsType,
+  from_subaccount: IDL.Opt(SubAccountType),
+  to: AccountIdentifierType,
+  block_height: IDL.Opt(IDL.Nat64),
+});
+
+/**
+ *
+ * @param {import("@lunarhq/rosetta-ts-client").ConstructionPayloadsResponse} payloads_res
+ * @returns {Buffer}
+ */
+function transaction_hash(payloads_res) {
+  const update = cbor_decode(hex_decode(payloads_res.unsigned_transaction));
+  assert(update.method_name === "send");
+  const send_args = SendArgs_decode(update.arg);
+  return sha256([
+    cbor_encode(
+      new Map([
+        [
+          0,
+          new Map([
+            [
+              2,
+              new Map([
+                [0, address_to_hex(principal_id_to_address(update.sender))],
+                [1, send_args.to],
+                [2, new Map([[0, send_args.amount]])],
+                [3, new Map([[0, send_args.fee]])],
+              ]),
+            ],
+          ]),
+        ],
+        [1, send_args.memo],
+        [2, send_args.block_height],
+      ])
+    ),
+  ]);
+}
+
+exports.transaction_hash = transaction_hash;
+
+/**
+ *
+ * @param {Buffer} buf
+ * @returns {object}
+ */
+function SendArgs_decode(buf) {
+  const arr = IDL.decode([SendArgsType], buf);
+  assert(arr.length === 1);
+  const send_args = arr[0];
+  return {
+    memo: bigintFromBigNumber(send_args.memo),
+    amount: bigintFromBigNumber(send_args.amount.doms),
+    fee: bigintFromBigNumber(send_args.fee.doms),
+    to: send_args.to,
+    block_height: bigintFromBigNumber(send_args.block_height[0]),
+  };
+}
+
+/**
+ *
+ * @param {import("bignumber.js").BigNumber} n
+ * @returns {bigint}
+ */
+function bigintFromBigNumber(n) {
+  return BigInt(n.toString());
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3590,7 +3590,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
       "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -3609,7 +3608,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
       "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -3617,7 +3615,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
       "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -3625,7 +3622,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
       "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3643,7 +3639,6 @@
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
       "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -3665,7 +3660,6 @@
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT"
     },
@@ -8989,8 +8983,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz",
           "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
@@ -9006,22 +8999,19 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz",
           "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4=",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz",
           "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
           "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "bundled": true,
-          "extraneous": true,
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
@@ -9036,8 +9026,7 @@
           "version": "3.9.1",
           "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
           "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash._root": {
           "version": "3.0.1",
@@ -9055,8 +9044,7 @@
           "version": "3.6.1",
           "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
           "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-          "bundled": true,
-          "extraneous": true
+          "bundled": true
         },
         "lodash.union": {
           "version": "4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@dfinity/agent": "^0.6.25",
         "@lunarhq/rosetta-ts-client": "^1.4.8-rc3",
         "cbor": "^7.0.4",
         "crc": "^3.8.0",
@@ -47,6 +48,36 @@
         "node": ">=4.9.1"
       }
     },
+    "node_modules/@dfinity/agent": {
+      "version": "0.6.25",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.6.25.tgz",
+      "integrity": "sha512-uIVeD3y15VsTVsZgsf6EM5g3KUTFtqDnDgQOe5LoUgGgDnBBaP8p6uStquqAJvg+UkGDr/LNuSpdYK8NkudF4A==",
+      "dependencies": {
+        "@types/crc": "^3.4.0",
+        "@types/jest": "^24.0.18",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.0.0",
+        "borc": "^2.1.1",
+        "buffer": "^5.4.3",
+        "buffer-pipe": "0.0.4",
+        "crc": "3.8.0",
+        "js-sha256": "0.9.0",
+        "simple-cbor": "^0.4.1"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@lunarhq/rosetta-ts-client": {
       "version": "1.4.8-rc3",
       "resolved": "https://registry.npmjs.org/@lunarhq/rosetta-ts-client/-/rosetta-ts-client-1.4.8-rc3.tgz",
@@ -59,15 +90,79 @@
         "openapi-typescript": "^2.4.2"
       }
     },
+    "node_modules/@types/crc": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/crc/-/crc-3.4.0.tgz",
+      "integrity": "sha1-I2a+tDmc1zSzPkLHrICVduYX1Io=",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "24.9.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
+      "integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
+      "dependencies": {
+        "jest-diff": "^24.3.0"
+      }
+    },
     "node_modules/@types/minimist": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg=="
     },
+    "node_modules/@types/node": {
+      "version": "14.14.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
+      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag=="
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA=="
+    },
+    "node_modules/@types/yargs": {
+      "version": "13.0.11",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
+      "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "20.2.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
+      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA=="
+    },
+    "node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -101,6 +196,14 @@
         "follow-redirects": "^1.10.0"
       }
     },
+    "node_modules/base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI=",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -110,10 +213,25 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
       "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/borc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
+      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0",
+        "buffer": "^5.5.0",
+        "commander": "^2.15.0",
+        "ieee754": "^1.1.13",
+        "iso-url": "~0.4.7",
+        "json-text-sequence": "~0.1.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/buffer": {
@@ -123,6 +241,14 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-pipe": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/buffer-pipe/-/buffer-pipe-0.0.4.tgz",
+      "integrity": "sha512-8cHio1V6wgX+LIX6+af4tCn0+Ljl2vQd9JZdZ8vDJZdDf8x5p2DneKaq1dWxSswJG+sK4Inok9aqoqILG5kQVQ==",
+      "dependencies": {
+        "safe-buffer": "^5.1.2"
       }
     },
     "node_modules/camelcase": {
@@ -193,6 +319,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "node_modules/crc": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
@@ -238,6 +369,19 @@
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delimit-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
+    },
+    "node_modules/diff-sequences": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+      "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/error-ex": {
@@ -340,6 +484,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -360,6 +509,41 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/iso-url": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
+      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+      "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+      "dependencies": {
+        "chalk": "^2.0.1",
+        "diff-sequences": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jest-get-type": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+      "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -386,6 +570,14 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "node_modules/json-text-sequence": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+      "dependencies": {
+        "delimit-stream": "0.1.0"
+      }
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -5911,6 +6103,20 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+      "dependencies": {
+        "@jest/types": "^24.9.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -5926,6 +6132,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/read-pkg": {
       "version": "5.2.0",
@@ -5994,6 +6205,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -6020,6 +6244,25 @@
       "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.4.0.tgz",
       "integrity": "sha512-3qIzGhHlMHA6PoT6+cdPKZ+ZqtxkIvg8DZGKA5z6PQ33/uuhoJ+Ws/D/J9rXW6gXodgH8QYlz2UCl+sdUDmNIg=="
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/semver": {
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
@@ -6033,6 +6276,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/simple-cbor": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
+      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w=="
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
@@ -6061,6 +6309,14 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
       "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ=="
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -6099,6 +6355,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -6152,6 +6413,33 @@
       "resolved": "https://registry.npmjs.org/@cto.af/textdecoder/-/textdecoder-0.0.0.tgz",
       "integrity": "sha512-sJpx3F5xcVV/9jNYJQtvimo4Vfld/nD3ph+ZWtQzZ03Zo8rJC7QKQTRcIGS13Rcz80DwFNthCWMrd58vpY4ZAQ=="
     },
+    "@dfinity/agent": {
+      "version": "0.6.25",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.6.25.tgz",
+      "integrity": "sha512-uIVeD3y15VsTVsZgsf6EM5g3KUTFtqDnDgQOe5LoUgGgDnBBaP8p6uStquqAJvg+UkGDr/LNuSpdYK8NkudF4A==",
+      "requires": {
+        "@types/crc": "^3.4.0",
+        "@types/jest": "^24.0.18",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.0.0",
+        "borc": "^2.1.1",
+        "buffer": "^5.4.3",
+        "buffer-pipe": "0.0.4",
+        "crc": "3.8.0",
+        "js-sha256": "0.9.0",
+        "simple-cbor": "^0.4.1"
+      }
+    },
+    "@jest/types": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+      "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^1.1.1",
+        "@types/yargs": "^13.0.0"
+      }
+    },
     "@lunarhq/rosetta-ts-client": {
       "version": "1.4.8-rc3",
       "resolved": "https://registry.npmjs.org/@lunarhq/rosetta-ts-client/-/rosetta-ts-client-1.4.8-rc3.tgz",
@@ -6164,15 +6452,76 @@
         "openapi-typescript": "^2.4.2"
       }
     },
+    "@types/crc": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/crc/-/crc-3.4.0.tgz",
+      "integrity": "sha1-I2a+tDmc1zSzPkLHrICVduYX1Io=",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
+    },
+    "@types/istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "@types/istanbul-reports": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+      "integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+      "requires": {
+        "@types/istanbul-lib-coverage": "*",
+        "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "24.9.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.9.1.tgz",
+      "integrity": "sha512-Fb38HkXSVA4L8fGKEZ6le5bB8r6MRWlOCZbVuWZcmOMSCd2wCYOwN1ibj8daIoV9naq7aaOZjrLCoCMptKU/4Q==",
+      "requires": {
+        "jest-diff": "^24.3.0"
+      }
+    },
     "@types/minimist": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
       "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg=="
     },
+    "@types/node": {
+      "version": "14.14.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
+      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag=="
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA=="
+    },
+    "@types/yargs": {
+      "version": "13.0.11",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.11.tgz",
+      "integrity": "sha512-NRqD6T4gktUrDi1o1wLH3EKC1o2caCr7/wR87ODcbVITQF106OM3sFN92ysZ++wqelOd1CTzatnOBRDYYG6wGQ==",
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "20.2.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz",
+      "integrity": "sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA=="
+    },
+    "ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -6200,6 +6549,11 @@
         "follow-redirects": "^1.10.0"
       }
     },
+    "base32.js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
+      "integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI="
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -6208,9 +6562,21 @@
     "bignumber.js": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==",
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+    },
+    "borc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/borc/-/borc-2.1.2.tgz",
+      "integrity": "sha512-Sy9eoUi4OiKzq7VovMn246iTo17kzuyHJKomCfpWMlI6RpfN1gk95w7d7gH264nApVLg0HZfcpz62/g4VH1Y4w==",
+      "requires": {
+        "bignumber.js": "^9.0.0",
+        "buffer": "^5.5.0",
+        "commander": "^2.15.0",
+        "ieee754": "^1.1.13",
+        "iso-url": "~0.4.7",
+        "json-text-sequence": "~0.1.0",
+        "readable-stream": "^3.6.0"
+      }
     },
     "buffer": {
       "version": "5.7.1",
@@ -6219,6 +6585,14 @@
       "requires": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
+      }
+    },
+    "buffer-pipe": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/buffer-pipe/-/buffer-pipe-0.0.4.tgz",
+      "integrity": "sha512-8cHio1V6wgX+LIX6+af4tCn0+Ljl2vQd9JZdZ8vDJZdDf8x5p2DneKaq1dWxSswJG+sK4Inok9aqoqILG5kQVQ==",
+      "requires": {
+        "safe-buffer": "^5.1.2"
       }
     },
     "camelcase": {
@@ -6268,6 +6642,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+    },
     "crc": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
@@ -6304,6 +6683,16 @@
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         }
       }
+    },
+    "delimit-stream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+      "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
+    },
+    "diff-sequences": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+      "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -6378,6 +6767,11 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -6395,6 +6789,32 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+    },
+    "iso-url": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-0.4.7.tgz",
+      "integrity": "sha512-27fFRDnPAMnHGLq36bWTpKET+eiXct3ENlCcdcMdk+mjXrb2kw3mhBUg1B7ewAC0kVzlOPhADzQgz1SE6Tglog=="
+    },
+    "jest-diff": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+      "integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+      "requires": {
+        "chalk": "^2.0.1",
+        "diff-sequences": "^24.9.0",
+        "jest-get-type": "^24.9.0",
+        "pretty-format": "^24.9.0"
+      }
+    },
+    "jest-get-type": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+      "integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q=="
+    },
+    "js-sha256": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
+      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -6418,6 +6838,14 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+    },
+    "json-text-sequence": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+      "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+      "requires": {
+        "delimit-stream": "0.1.0"
+      }
     },
     "kind-of": {
       "version": "6.0.3",
@@ -10560,6 +10988,17 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q=="
     },
+    "pretty-format": {
+      "version": "24.9.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+      "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+      "requires": {
+        "@jest/types": "^24.9.0",
+        "ansi-regex": "^4.0.0",
+        "ansi-styles": "^3.2.0",
+        "react-is": "^16.8.4"
+      }
+    },
     "propagate": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
@@ -10569,6 +11008,11 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "read-pkg": {
       "version": "5.2.0",
@@ -10626,6 +11070,16 @@
         }
       }
     },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -10649,6 +11103,11 @@
       "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.4.0.tgz",
       "integrity": "sha512-3qIzGhHlMHA6PoT6+cdPKZ+ZqtxkIvg8DZGKA5z6PQ33/uuhoJ+Ws/D/J9rXW6gXodgH8QYlz2UCl+sdUDmNIg=="
     },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
     "semver": {
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
@@ -10656,6 +11115,11 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "simple-cbor": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/simple-cbor/-/simple-cbor-0.4.1.tgz",
+      "integrity": "sha512-rijcxtwx2b4Bje3sqeIqw5EeW7UlOIC4YfOdwqIKacpvRQ/D78bWg/4/0m5e0U91oKvlGh7LlJuZCu07ISCC7w=="
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -10685,6 +11149,14 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
       "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ=="
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -10710,6 +11182,11 @@
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
       "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/dfinity-lab/dfinity-js-sdk",
   "dependencies": {
+    "@dfinity/agent": "^0.6.25",
     "@lunarhq/rosetta-ts-client": "^1.4.8-rc3",
     "cbor": "^7.0.4",
     "crc": "^3.8.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1,8 +1,14 @@
-const { hex_decode, Chain, Session, transfer_combine } = require("../index.js");
+const {
+  hex_decode,
+  address_from_hex,
+  Chain,
+  Session,
+  transfer_combine,
+} = require("../index.js");
 const { inspect } = require("util");
 
 (async () => {
-  const session = new Session({ baseUrl: "http://localhost:8080" });
+  const session = new Session({ baseUrl: "http://localhost:2054" });
   const chain = new Chain(session);
 
   try {
@@ -10,7 +16,9 @@ const { inspect } = require("util");
       hex_decode(
         "093c3e2191be336f246259769041dd75b326143746b2ca97cb0f66273a366ba5ae7c3e96d49d7e5b1f74ce1e8ff640957c3ba4d7199f463a9fcff4c68b19f5e3"
       ),
-      hex_decode("df11fdc42d372cea555c5b1c0e73c67ea103d1e8a4d0e669a0b9d4ac02"),
+      address_from_hex(
+        "1e1838071cb875e59c1da64af5e04951bb3c1e94c1285bf9ff7480a645e1aa56"
+      ),
       1000000n
     );
 
@@ -23,8 +31,12 @@ const { inspect } = require("util");
     );
 
     let payloads_res = await session.transfer_pre_combine(
-      hex_decode("89b481c08f663adc356d99f6651082e84408302c97da41a02a70991002"),
-      hex_decode("df11fdc42d372cea555c5b1c0e73c67ea103d1e8a4d0e669a0b9d4ac02"),
+      hex_decode(
+        "ae7c3e96d49d7e5b1f74ce1e8ff640957c3ba4d7199f463a9fcff4c68b19f5e3"
+      ),
+      address_from_hex(
+        "1e1838071cb875e59c1da64af5e04951bb3c1e94c1285bf9ff7480a645e1aa56"
+      ),
       1000000n
     );
     let combine_res = transfer_combine(

--- a/test/test.js
+++ b/test/test.js
@@ -1,10 +1,4 @@
-const {
-  hex_decode,
-  address_from_hex,
-  Chain,
-  Session,
-  transfer_combine,
-} = require("../index.js");
+const { hex_decode, address_from_hex, Chain, Session } = require("../index.js");
 const { inspect } = require("util");
 
 (async () => {
@@ -21,31 +15,6 @@ const { inspect } = require("util");
       ),
       1000000n
     );
-
-    await new Promise((res) => setTimeout(res, 10000));
-
-    console.log(
-      inspect(chain.get_transaction(submit_res.transaction_identifier.hash), {
-        depth: null,
-      })
-    );
-
-    let payloads_res = await session.transfer_pre_combine(
-      hex_decode(
-        "ae7c3e96d49d7e5b1f74ce1e8ff640957c3ba4d7199f463a9fcff4c68b19f5e3"
-      ),
-      address_from_hex(
-        "1e1838071cb875e59c1da64af5e04951bb3c1e94c1285bf9ff7480a645e1aa56"
-      ),
-      1000000n
-    );
-    let combine_res = transfer_combine(
-      hex_decode(
-        "093c3e2191be336f246259769041dd75b326143746b2ca97cb0f66273a366ba5ae7c3e96d49d7e5b1f74ce1e8ff640957c3ba4d7199f463a9fcff4c68b19f5e3"
-      ),
-      payloads_res
-    );
-    submit_res = await session.transfer_post_combine(combine_res);
 
     await new Promise((res) => setTimeout(res, 10000));
 

--- a/test/test.js
+++ b/test/test.js
@@ -8,7 +8,7 @@ const {
 const { inspect } = require("util");
 
 (async () => {
-  const session = new Session({ baseUrl: "http://localhost:2054" });
+  const session = new Session({ baseUrl: "http://localhost:8080" });
   const chain = new Chain(session);
 
   try {


### PR DESCRIPTION
* Implement new address generation logic as in upstream
* `address_from_hex`/`address_to_hex` are now required for encoding/decoding addresses instead of `hex_decode`/`hex_encode`
* `transfer_pre_combine` now require source account public key instead of address, since `/construction/payloads` now requires `public_keys` field
* Implement offline transaction hash calculation for now, though this may be stripped before the next release (users should favor `/construction/hash` whenever possible)