### PR TITLE
Use @dfinity/agent, @dfinity/authentication for various internal logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ const payloads_result = await session.transfer_pre_combine(
 // This step can be executed in a fully isolated environment.
 //
 // 该步骤可在完全隔离的环境中执行。
-const combine_result = transfer_combine(source_private_key, payloads_result);
+const combine_result = await transfer_combine(source_private_key, payloads_result);
 
 const submit_result = await session.transfer_post_combine(combine_result);
 

--- a/README.md
+++ b/README.md
@@ -10,57 +10,112 @@ helper functions to derive keys/accounts and perform transfers.
 
 ## Usage
 
+### Working with ED25519 keys
+
 ```javascript
-const {
-  key_new,
-  key_to_pub_key,
+let {
+  // The class for ED25519 public key objects
+  //
+  // ED25519 公钥类型
+  Ed25519PublicKey,
+
+  // The class for ED25519 private key objects
+  //
+  // ED25519 私钥类型
+  Ed25519KeyIdentity,
+} = require("@dfinity/rosetta-client");
+
+// Derive an ED25519 private key from a system random seed.
+//
+// 从系统生成的随机种子生成一个 ED25519 私钥。
+let privateKey = Ed25519KeyIdentity.generate();
+
+// Derive an ED25519 private key from a user-specified 32-byte random seed. This
+// is the preferred way of generating private keys, since the seed can be stored
+// and be used by other ED25519 implementations as well.
+//
+// 从用户指定的 32 字节随机数种子生成一个 ED25519 私钥。我们推荐使用本方式生成私
+// 钥，因为可以存储随机数种子，且该种子可用于在其他 ED25519 实现中生成同一个私
+// 钥。
+let seed = Buffer.allocUnsafe(32);
+privateKey = Ed25519KeyIdentity.generate(seed);
+
+// Ed25519KeyIdentity supports serialization via JSON.
+//
+// Ed25519KeyIdentity 类型支持 JSON 序列化。
+privateKey = Ed25519KeyIdentity.fromJSON(JSON.stringify(privateKey));
+
+// The getKeyPair() method returns an object with two fields: publicKey &
+// secretKey. The publicKey field is an Ed25519PublicKey object, while the
+// secretKey field is a Buffer.
+//
+// getKeyPair() 方法返回的对象包含 publicKey 和 secretKey 属性。publicKey 是
+// Ed25519PublicKey 类的对象，secretKey 是 Buffer。
+let keyPair = privateKey.getKeyPair();
+
+// Ed25519KeyIdentity can also be deserialized by providing the keyPair's
+// Buffers or the secretKey buffer alone.
+//
+// Ed25519KeyIdentity 类型也可通过提供 keyPair 中的一对 Buffer 或仅提供
+// secretKey 的 Buffer，进行反序列化。
+privateKey = Ed25519KeyIdentity.fromKeyPair(
+  keyPair.publicKey.toRaw(),
+  keyPair.secretKey
+);
+privateKey = Ed25519KeyIdentity.fromSecretKey(keyPair.secretKey);
+
+// The getPublicKey() method returns an Ed25519PublicKey object.
+//
+// getPublicKey() 方法返回一个 Ed25519PublicKey 对象。
+let publicKey = privateKey.getPublicKey();
+
+// The toRaw() method of the Ed25519PublicKey class returns a Buffer, which can
+// be used to deserialize the public key via Ed25519PublicKey.fromRaw().
+//
+// Ed25519PublicKey 类的 toRaw() 方法返回一个 Buffer，可用于调用
+// Ed25519PublicKey.fromRaw() 进行反序列化。
+publicKey = Ed25519PublicKey.fromRaw(publicKey.toRaw());
+```
+
+### Working with account addresses
+
+```javascript
+let {
   pub_key_to_address,
   address_from_hex,
   address_to_hex,
-  Chain,
-  Session,
-  transaction_hash,
-  transfer_combine,
 } = require("@dfinity/rosetta-client");
 
-// Generate a new private key. A private key is a Buffer and can be used to
-// generate the public account address and perform transfers.
+// pub_key_to_address() derives an address from an Ed25519PublicKey object. The
+// address type is Buffer.
 //
-// 生成新的私钥。私钥类型为 Buffer，用于生成公开的账户地址、进行转账。
-let key = key_new();
+// pub_key_to_address() 函数从 Ed25519PublicKey 对象生成账户地址。地址类型是
+// Buffer。
+let address = pub_key_to_address(publicKey);
 
-// Generate a private key given a 32-byte binary seed. This is the preferred way
-// of generating private keys, since the seed can be stored and it can be used
-// by other languages/frameworks as well.
+// address_from_hex() & address_to_hex() converts between the address Buffer and
+// the hex address string used in Rosetta API requests. This is not a simple
+// base16 encoding, since the hex string will also contain a CRC32 checksum.
+// address_from_hex() will throw if the checksum doesn't match.
 //
-// 使用 32 字节的随机数种子生成私钥。我们推荐使用本方式生成私钥，因为可以存储随
-// 机数种子，且该种子可在其他语言/框架中重新构造相同的密钥。
-const seed = Buffer.allocUnsafe(32);
-key = key_new({ seed: seed });
+// address_from_hex() 和 address_to_hex() 函数用于在地址的 Buffer 和用于 Rosetta
+// API 请求中的十六进制字符串之间进行转换。转换过程并非简单的 base16 编码，因为
+// 十六进制字符串中还会包含一个 CRC32 校验码。address_from_hex() 在校验码错误时
+// 会抛出异常。
+address = address_from_hex(address_to_hex(address));
+```
 
-// Generate the public account address from a private key. The result is a
-// Buffer. Use address_to_hex() to generate the string representation used in
-// the address field of requests.
-//
-// 从私钥生成公开的账户地址。账户地址类型为 Buffer，用 address_to_hex() 可以将其
-// 编码为在请求的 address 一栏中所用的地址字符串。
-const address = pub_key_to_address(key_to_pub_key(key));
-console.log(address_to_hex(address));
+### Calling Rosetta API and performing transfers
+
+```javascript
+let { Session } = require("@dfinity/rosetta-client");
 
 // A Session is a subclass of RosettaClient, and you can use methods of
 // RosettaClient to invoke the Rosetta API.
 //
 // Session 是 RosettaClient 的子类，可以调用 RosettaClient 的方法使用 Rosetta
 // API。
-const session = new Session({ baseUrl: "http://localhost:8080" });
-
-// A Chain is a service which polls recent blocks, and can be used to confirm if
-// a transaction actually hit the chain given the transaction hash. It's not
-// required for performing transfers.
-//
-// Chain 类实现了轮询最近新增的区块的逻辑，给定转账事务的 hash 值，可用于确认该
-// 事务成功上链。转账操作本身并不需要此类对象。
-const chain = new Chain(session);
+let session = new Session({ baseUrl: "http://localhost:8080" });
 
 // The network_identifier value used in requests.
 //
@@ -79,44 +134,25 @@ console.log(await session.currency);
 // 强制的。
 console.log(await session.suggested_fee);
 
-// Given the source account's private key, the destination account's address and
-// the amount, perform a transfer and return the result of the
-// /construction/submit call.
+// Given the source account private key as an Ed25519KeyIdentity object, the
+// destination account as a Buffer, the transfer amount as a BigInt, perform a
+// transfer and return the result of the /construction/submit call.
 //
 // The destination account will receive the specified amount. An additional fee
-// will be debited from the source account.
+// will be charged from the source account.
 //
-// 给定划出账户的私钥、划入账户的地址和转账数额，发起一次转账，并返回该事务的
-// /construction/submit 调用结果。
+// 给定划出账户私钥的 Ed25519KeyIdentity 对象、划入账户地址的 Buffer 对象和划转
+// 金额的 BigInt 值，发起一次转账，并返回 /construction/submit 调用的结果。
 //
-// 划入账户将收到参数指定的转账数额。划出账户将额外扣除交易费用。
-const submit_result = await session.transfer(
-  key,
-  address_from_hex(destination_address_hex_string),
-  123n
-);
+// 划入账户将收到指定金额，划出账户则将额外扣除交易费用。
+let submit_result = await session.transfer(src_private_key, dest_addr, 123n);
 console.log(submit_result);
+```
 
-// Before confirming if the transaction actually reached the chain, wait for a
-// bit of time.
-//
-// 确认转账事务上链之前，等待片刻时间。
-await new Promise((res) => setTimeout(res, 10000));
+### Performing transfers while keeping the private keys in an isolated environment
 
-// Lookup a transaction in recent blocks given its hash value. If the result is
-// not undefined, the transaction has actually reached the chain.
-//
-// 在最近新增的区块中检索转账事务的 hash。若返回值非 undefined，则该事务确认上
-// 链。
-const transaction = chain.get_transaction(
-  submit_result.transaction_identifier.hash
-);
-console.log(transaction);
-
-// Stop polling recent blocks.
-//
-// 停止轮询最近新增的区块。
-chain.close();
+```javascript
+let { transfer_combine } = require("@dfinity/rosetta-client");
 
 // Due to security concerns, you may wish to avoid calling transfer() which
 // consumes the private key and performs network calls. We support using the
@@ -125,29 +161,18 @@ chain.close();
 //
 // 出于安全考虑，您也许希望避免调用 transfer() 方法，因为它需要传入私钥参数，并
 // 且会执行网络调用。我们支持在转账时，仅在完全隔离的环境中使用私钥，用例如下。
-
-const payloads_result = await session.transfer_pre_combine(
-  source_pub_key,
-  destination_address,
+let payloads_result = await session.transfer_pre_combine(
+  src_public_key,
+  dest_addr,
   123n
 );
 
 // This step can be executed in a fully isolated environment.
 //
 // 该步骤可在完全隔离的环境中执行。
-const combine_result = await transfer_combine(source_private_key, payloads_result);
+let combine_result = await transfer_combine(src_private_key, payloads_result);
 
-const submit_result = await session.transfer_post_combine(combine_result);
-
-// There are two ways to obtain a transaction hash. One is reading the result of
-// /construction/submit call, another is using transaction_hash() to calculate
-// it locally.
-//
-// 有两种计算 transaction hash 的方法。第一种是从 /construction/submit 调用的结
-// 果读取，第二种是调用 transaction_hash() 函数离线计算。
-
-const tx_hash = transaction_hash(payloads_result);
-assert(hex_encode(tx_hash) === submit_result.transaction_identifier.hash);
+submit_result = await session.transfer_post_combine(combine_result);
 ```
 
 ## Supported Node.js versions

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = {
   ...require("./lib/chain"),
   ...require("./lib/construction_combine"),
   ...require("./lib/key"),
+  ...require("./lib/patch"),
   ...require("./lib/session"),
   ...require("./lib/stats"),
   ...require("./lib/transaction_hash"),

--- a/index.js
+++ b/index.js
@@ -1,5 +1,15 @@
+const { blobFromHex, blobToHex } = require("@dfinity/agent");
+const {
+  Ed25519PublicKey,
+  Ed25519KeyIdentity,
+} = require("@dfinity/authentication");
+
 // Use specific export syntax to allow bundlers and IDEs to properly load dependencies.
 module.exports = {
+  blobFromHex: blobFromHex,
+  blobToHex: blobToHex,
+  Ed25519PublicKey: Ed25519PublicKey,
+  Ed25519KeyIdentity: Ed25519KeyIdentity,
   ...require("./lib/chain"),
   ...require("./lib/construction_combine"),
   ...require("./lib/key"),

--- a/lib/construction_combine.js
+++ b/lib/construction_combine.js
@@ -1,32 +1,29 @@
 const assert = require("assert").strict;
+const authentication = require("@dfinity/authentication");
 const cbor = require("cbor");
 const { cbor_decode, cbor_encode } = require("./cbor.js");
 const { sha256 } = require("./hash.js");
-const {
-  hex_decode,
-  hex_encode,
-  key_sign,
-  key_to_pub_key,
-  pub_key_to_der,
-} = require("./key.js");
+const { hex_decode, hex_encode } = require("./key.js");
 
 /**
  *
- * @param {Buffer} src_key
+ * @param {import("@dfinity/authentication").Ed25519KeyIdentity} src_identity
  * @param {import("@lunarhq/rosetta-ts-client").ConstructionPayloadsResponse} payloads_res
  * @returns {Promise<import("@lunarhq/rosetta-ts-client").ConstructionCombineResponse>}
  */
-async function transfer_combine(src_key, payloads_res) {
+async function transfer_combine(src_identity, payloads_res) {
   return combine({
-    signatures: payloads_res.payloads.map((p) => ({
-      signing_payload: p,
-      public_key: {
-        hex_bytes: hex_encode(key_to_pub_key(src_key)),
-        curve_type: "edwards25519",
-      },
-      signature_type: "ed25519",
-      hex_bytes: hex_encode(key_sign(src_key, hex_decode(p.hex_bytes))),
-    })),
+    signatures: await Promise.all(
+      payloads_res.payloads.map(async (p) => ({
+        signing_payload: p,
+        public_key: {
+          hex_bytes: hex_encode(src_identity.getPublicKey().toRaw()),
+          curve_type: "edwards25519",
+        },
+        signature_type: "ed25519",
+        hex_bytes: hex_encode(await src_identity.sign(hex_decode(p.hex_bytes))),
+      }))
+    ),
     unsigned_transaction: payloads_res.unsigned_transaction,
   });
 }
@@ -59,9 +56,9 @@ function combine(req) {
 
   const envelope = {
     content: Object.assign({ request_type: "call" }, update),
-    sender_pubkey: pub_key_to_der(
+    sender_pubkey: authentication.Ed25519PublicKey.fromRaw(
       hex_decode(transaction_signature.public_key.hex_bytes)
-    ),
+    ).toDer(),
     sender_sig: hex_decode(transaction_signature.hex_bytes),
     sender_delegation: null,
   };
@@ -69,9 +66,9 @@ function combine(req) {
 
   const read_state_envelope = {
     content: Object.assign({ request_type: "read_state" }, read_state),
-    sender_pubkey: pub_key_to_der(
+    sender_pubkey: authentication.Ed25519PublicKey.fromRaw(
       hex_decode(read_state_signature.public_key.hex_bytes)
-    ),
+    ).toDer(),
     sender_sig: hex_decode(read_state_signature.hex_bytes),
     sender_delegation: null,
   };

--- a/lib/construction_combine.js
+++ b/lib/construction_combine.js
@@ -1,9 +1,10 @@
 const assert = require("assert").strict;
+const { blobToHex } = require("@dfinity/agent");
 const authentication = require("@dfinity/authentication");
 const cbor = require("cbor");
 const { cbor_decode, cbor_encode } = require("./cbor.js");
 const { sha256 } = require("./hash.js");
-const { hex_decode, hex_encode } = require("./key.js");
+const { hex_decode } = require("./key.js");
 
 /**
  *
@@ -17,11 +18,11 @@ async function transfer_combine(src_identity, payloads_res) {
       payloads_res.payloads.map(async (p) => ({
         signing_payload: p,
         public_key: {
-          hex_bytes: hex_encode(src_identity.getPublicKey().toRaw()),
+          hex_bytes: blobToHex(src_identity.getPublicKey().toRaw()),
           curve_type: "edwards25519",
         },
         signature_type: "ed25519",
-        hex_bytes: hex_encode(await src_identity.sign(hex_decode(p.hex_bytes))),
+        hex_bytes: blobToHex(await src_identity.sign(hex_decode(p.hex_bytes))),
       }))
     ),
     unsigned_transaction: payloads_res.unsigned_transaction,
@@ -75,7 +76,7 @@ function combine(req) {
   read_state_envelope.content.encodeCBOR = cbor.Encoder.encodeIndefinite;
 
   const envelopes = [envelope, read_state_envelope];
-  const signed_transaction = hex_encode(cbor_encode(envelopes));
+  const signed_transaction = blobToHex(cbor_encode(envelopes));
 
   return { signed_transaction: signed_transaction };
 }

--- a/lib/construction_combine.js
+++ b/lib/construction_combine.js
@@ -1,10 +1,9 @@
 const assert = require("assert").strict;
-const { blobToHex } = require("@dfinity/agent");
+const { blobFromHex, blobToHex } = require("@dfinity/agent");
 const authentication = require("@dfinity/authentication");
 const cbor = require("cbor");
 const { cbor_decode, cbor_encode } = require("./cbor.js");
 const { sha256 } = require("./hash.js");
-const { hex_decode } = require("./key.js");
 
 /**
  *
@@ -22,7 +21,7 @@ async function transfer_combine(src_identity, payloads_res) {
           curve_type: "edwards25519",
         },
         signature_type: "ed25519",
-        hex_bytes: blobToHex(await src_identity.sign(hex_decode(p.hex_bytes))),
+        hex_bytes: blobToHex(await src_identity.sign(blobFromHex(p.hex_bytes))),
       }))
     ),
     unsigned_transaction: payloads_res.unsigned_transaction,
@@ -38,19 +37,19 @@ exports.transfer_combine = transfer_combine;
 function combine(req) {
   assert(req.signatures.length === 2);
 
-  const update = cbor_decode(hex_decode(req.unsigned_transaction));
+  const update = cbor_decode(blobFromHex(req.unsigned_transaction));
   const read_state = make_read_state_from_update(update);
 
   const transaction_signature = req.signatures.find(
     (sig) =>
-      hex_decode(sig.signing_payload.hex_bytes).compare(
+      blobFromHex(sig.signing_payload.hex_bytes).compare(
         make_sig_data(HttpCanisterUpdate_id(update))
       ) === 0
   );
 
   const read_state_signature = req.signatures.find(
     (sig) =>
-      hex_decode(sig.signing_payload.hex_bytes).compare(
+      blobFromHex(sig.signing_payload.hex_bytes).compare(
         make_sig_data(HttpReadState_representation_independent_hash(read_state))
       ) === 0
   );
@@ -58,9 +57,9 @@ function combine(req) {
   const envelope = {
     content: Object.assign({ request_type: "call" }, update),
     sender_pubkey: authentication.Ed25519PublicKey.fromRaw(
-      hex_decode(transaction_signature.public_key.hex_bytes)
+      blobFromHex(transaction_signature.public_key.hex_bytes)
     ).toDer(),
-    sender_sig: hex_decode(transaction_signature.hex_bytes),
+    sender_sig: blobFromHex(transaction_signature.hex_bytes),
     sender_delegation: null,
   };
   envelope.content.encodeCBOR = cbor.Encoder.encodeIndefinite;
@@ -68,9 +67,9 @@ function combine(req) {
   const read_state_envelope = {
     content: Object.assign({ request_type: "read_state" }, read_state),
     sender_pubkey: authentication.Ed25519PublicKey.fromRaw(
-      hex_decode(read_state_signature.public_key.hex_bytes)
+      blobFromHex(read_state_signature.public_key.hex_bytes)
     ).toDer(),
-    sender_sig: hex_decode(read_state_signature.hex_bytes),
+    sender_sig: blobFromHex(read_state_signature.hex_bytes),
     sender_delegation: null,
   };
   read_state_envelope.content.encodeCBOR = cbor.Encoder.encodeIndefinite;

--- a/lib/construction_combine.js
+++ b/lib/construction_combine.js
@@ -14,9 +14,9 @@ const {
  *
  * @param {Buffer} src_key
  * @param {import("@lunarhq/rosetta-ts-client").ConstructionPayloadsResponse} payloads_res
- * @returns {import("@lunarhq/rosetta-ts-client").ConstructionCombineResponse}
+ * @returns {Promise<import("@lunarhq/rosetta-ts-client").ConstructionCombineResponse>}
  */
-function transfer_combine(src_key, payloads_res) {
+async function transfer_combine(src_key, payloads_res) {
   return combine({
     signatures: payloads_res.payloads.map((p) => ({
       signing_payload: p,

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -1,4 +1,4 @@
-const crypto = require("crypto");
+const js_sha256 = require("js-sha256");
 
 /**
  *
@@ -6,9 +6,9 @@ const crypto = require("crypto");
  * @returns {Buffer}
  */
 function sha256(chunks) {
-  const hasher = crypto.createHash("sha256");
+  const hasher = js_sha256.sha256.create();
   chunks.forEach((chunk) => hasher.update(chunk));
-  return hasher.digest();
+  return Buffer.from(hasher.arrayBuffer());
 }
 
 exports.sha256 = sha256;
@@ -19,9 +19,9 @@ exports.sha256 = sha256;
  * @returns {Buffer}
  */
 function sha224(chunks) {
-  const h = crypto.createHash("sha224");
-  chunks.forEach((chunk) => h.update(chunk));
-  return h.digest();
+  const hasher = js_sha256.sha224.create();
+  chunks.forEach((chunk) => hasher.update(chunk));
+  return Buffer.from(hasher.arrayBuffer());
 }
 
 exports.sha224 = sha224;

--- a/lib/key.js
+++ b/lib/key.js
@@ -1,7 +1,6 @@
 const assert = require("assert").strict;
 const agent = require("@dfinity/agent");
 const crc = require("crc");
-const forge = require("node-forge");
 const rfc4648 = require("rfc4648");
 const { sha224 } = require("./hash.js");
 
@@ -37,20 +36,6 @@ function hex_encode(buf) {
 exports.hex_encode = hex_encode;
 
 /**
- * This is used to decode the textual representation of an account address. The
- * return value needs further processing.
- * @param {string} s
- * @returns {Buffer}
- */
-function base32_decode(s) {
-  return bufferFromArrayBufferView(
-    rfc4648.base32.parse(s.trim().replaceAll("-", ""), {
-      loose: true,
-    })
-  );
-}
-
-/**
  * Given an account address with a prepended big-endian CRC32 checksum, verify
  * the checksum and remove it.
  * @param {Buffer} buf
@@ -74,99 +59,6 @@ function crc32_add(buf) {
   return res;
 }
 
-/**
- * Given an account address with a prepended big-endian CRC32 checksum, generate
- * its textual representation.
- * @param {Buffer} buf
- * @returns {string}
- */
-function base32_encode(buf) {
-  let s = rfc4648.base32.stringify(buf, { pad: false });
-  let acc = "";
-  while (s) {
-    acc = `${acc}${s.substr(0, 5).toLowerCase()}${s.length > 5 ? "-" : ""}`;
-    s = s.substr(5);
-  }
-  return acc;
-}
-
-/**
- * Generate a new private key.
- *
- * To specify a 32-byte binary seed, pass {seed: seed_buffer} as the argument.
- * @returns {Buffer}
- */
-function key_new(options) {
-  return forge.pki.ed25519.generateKeyPair(options).privateKey;
-}
-
-exports.key_new = key_new;
-
-/**
- * Given a private key, generate its public key used for signing.
- * @param {Buffer} priv_key
- * @returns {Buffer}
- */
-function key_to_pub_key(priv_key) {
-  return forge.pki.ed25519.publicKeyFromPrivateKey({
-    privateKey: priv_key,
-  });
-}
-
-exports.key_to_pub_key = key_to_pub_key;
-
-/**
- * Given a private key, sign a message.
- * @param {Buffer} priv_key
- * @param {Buffer} msg
- * @returns {Buffer}
- */
-function key_sign(priv_key, msg) {
-  return forge.pki.ed25519.sign({ message: msg, privateKey: priv_key });
-}
-
-exports.key_sign = key_sign;
-
-const der_header = Buffer.from([
-  0x30,
-  0x2a,
-  0x30,
-  0x05,
-  0x06,
-  0x03,
-  0x2b,
-  0x65,
-  0x70,
-  0x03,
-  0x21,
-  0x00,
-]);
-
-/**
- *
- * @param {Buffer} pub_key
- */
-function pub_key_to_der(pub_key) {
-  assert(pub_key.byteLength === 32);
-  let buf = Buffer.allocUnsafe(12 + 32);
-  der_header.copy(buf, 0);
-  pub_key.copy(buf, 12);
-  return buf;
-}
-
-exports.pub_key_to_der = pub_key_to_der;
-
-/**
- *
- * @param {Buffer} buf
- */
-function pub_key_from_der(buf) {
-  return Buffer.from(
-    forge.asn1.fromDer(forge.util.createBuffer(buf)).value[1].value,
-    "binary"
-  ).subarray(1);
-}
-
 const SUB_ACCOUNT_ZERO = Buffer.alloc(32);
 const ACCOUNT_DOMAIN_SEPERATOR = Buffer.from("\x0Aaccount-id");
 
@@ -183,13 +75,12 @@ exports.principal_id_to_address = principal_id_to_address;
 
 /**
  * Given a public key, generate the account address.
- * @param {Buffer} pub_key
+ * @param {import("@dfinity/authentication").Ed25519PublicKey} pub_key
  * @returns {Buffer}
  */
 function pub_key_to_address(pub_key) {
-  assert(pub_key.byteLength === 32);
   return principal_id_to_address(
-    agent.Principal.selfAuthenticating(pub_key_to_der(pub_key))
+    agent.Principal.selfAuthenticating(pub_key.toDer())
   );
 }
 

--- a/lib/key.js
+++ b/lib/key.js
@@ -25,17 +25,6 @@ function hex_decode(s) {
 exports.hex_decode = hex_decode;
 
 /**
- *
- * @param {Buffer} buf
- * @returns {string}
- */
-function hex_encode(buf) {
-  return rfc4648.base16.stringify(buf).toLowerCase();
-}
-
-exports.hex_encode = hex_encode;
-
-/**
  * Given an account address with a prepended big-endian CRC32 checksum, verify
  * the checksum and remove it.
  * @param {Buffer} buf
@@ -105,7 +94,7 @@ exports.address_from_hex = address_from_hex;
  * @returns {string}
  */
 function address_to_hex(addr_buf) {
-  return hex_encode(crc32_add(addr_buf));
+  return agent.blobToHex(crc32_add(addr_buf));
 }
 
 exports.address_to_hex = address_to_hex;

--- a/lib/key.js
+++ b/lib/key.js
@@ -1,7 +1,6 @@
 const assert = require("assert").strict;
 const agent = require("@dfinity/agent");
 const crc = require("crc");
-const rfc4648 = require("rfc4648");
 const { sha224 } = require("./hash.js");
 
 /**
@@ -12,17 +11,6 @@ const { sha224 } = require("./hash.js");
 function bufferFromArrayBufferView(buf) {
   return Buffer.from(buf.buffer, buf.byteOffset, buf.byteLength);
 }
-
-/**
- *
- * @param {string} s
- * @returns {Buffer}
- */
-function hex_decode(s) {
-  return bufferFromArrayBufferView(rfc4648.base16.parse(s));
-}
-
-exports.hex_decode = hex_decode;
 
 /**
  * Given an account address with a prepended big-endian CRC32 checksum, verify
@@ -81,7 +69,7 @@ exports.pub_key_to_address = pub_key_to_address;
  * @returns {Buffer}
  */
 function address_from_hex(hex_str) {
-  const buf = hex_decode(hex_str);
+  const buf = bufferFromArrayBufferView(agent.blobFromHex(hex_str));
   assert(buf.byteLength === 32);
   return crc32_del(buf);
 }

--- a/lib/key.js
+++ b/lib/key.js
@@ -1,13 +1,9 @@
 const assert = require("assert").strict;
+const agent = require("@dfinity/agent");
 const crc = require("crc");
 const forge = require("node-forge");
 const rfc4648 = require("rfc4648");
 const { sha224 } = require("./hash.js");
-
-/**
- * The principal ids we create are always self-authenticating ones.
- */
-const TYPE_SELF_AUTH = 0x02;
 
 /**
  * Instead of Buffer.from(), this doesn't do a new allocation.
@@ -171,29 +167,16 @@ function pub_key_from_der(buf) {
   ).subarray(1);
 }
 
-/**
- *
- * @param {Buffer} pub_key
- * @returns {Buffer}
- */
-function pub_key_to_principal_id(pub_key) {
-  const pub_key_der_hash = sha224([pub_key_to_der(pub_key)]);
-  const principal_id_buf = Buffer.allocUnsafe(pub_key_der_hash.length + 1);
-  pub_key_der_hash.copy(principal_id_buf, 0);
-  principal_id_buf.writeUInt8(TYPE_SELF_AUTH, pub_key_der_hash.length);
-  return principal_id_buf;
-}
-
 const SUB_ACCOUNT_ZERO = Buffer.alloc(32);
 const ACCOUNT_DOMAIN_SEPERATOR = Buffer.from("\x0Aaccount-id");
 
 /**
  *
- * @param {Buffer} pid
+ * @param {import("@dfinity/agent").Principal} pid
  * @returns {Buffer}
  */
 function principal_id_to_address(pid) {
-  return sha224([ACCOUNT_DOMAIN_SEPERATOR, pid, SUB_ACCOUNT_ZERO]);
+  return sha224([ACCOUNT_DOMAIN_SEPERATOR, pid.toBlob(), SUB_ACCOUNT_ZERO]);
 }
 
 exports.principal_id_to_address = principal_id_to_address;
@@ -205,7 +188,9 @@ exports.principal_id_to_address = principal_id_to_address;
  */
 function pub_key_to_address(pub_key) {
   assert(pub_key.byteLength === 32);
-  return principal_id_to_address(pub_key_to_principal_id(pub_key));
+  return principal_id_to_address(
+    agent.Principal.selfAuthenticating(pub_key_to_der(pub_key))
+  );
 }
 
 exports.pub_key_to_address = pub_key_to_address;
@@ -233,21 +218,3 @@ function address_to_hex(addr_buf) {
 }
 
 exports.address_to_hex = address_to_hex;
-
-/**
- * Given an account address, generate its textual representation.
- * @param {Buffer} buf
- * @returns {string}
- */
-function principal_id_encode(buf) {
-  return base32_encode(crc32_add(buf));
-}
-
-/**
- * Decode the textual representation of an account address.
- * @param {string} s
- * @returns {Buffer}
- */
-function principal_id_decode(s) {
-  return crc32_del(base32_decode(s));
-}

--- a/lib/patch.js
+++ b/lib/patch.js
@@ -1,0 +1,12 @@
+const authentication = require("@dfinity/authentication");
+const tweetnacl = require("tweetnacl");
+
+if (!authentication.Ed25519KeyIdentity.fromSecretKey) {
+  authentication.Ed25519KeyIdentity.fromSecretKey = (secretKey) => {
+    const keyPair = tweetnacl.sign.keyPair.fromSecretKey(secretKey);
+    return authentication.Ed25519KeyIdentity.fromKeyPair(
+      keyPair.publicKey,
+      keyPair.secretKey
+    );
+  };
+}

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,6 +1,7 @@
 const assert = require("assert").strict;
+const { blobToHex } = require("@dfinity/agent");
 const { RosettaClient } = require("@lunarhq/rosetta-ts-client");
-const { pub_key_to_address, address_to_hex, hex_encode } = require("./key.js");
+const { pub_key_to_address, address_to_hex } = require("./key.js");
 const { transfer_combine } = require("./construction_combine.js");
 const { transaction_hash } = require("./transaction_hash.js");
 
@@ -89,7 +90,7 @@ class Session extends RosettaClient {
       metadata: (await this.metadata({ network_identifier: net_id })).metadata,
       public_keys: [
         {
-          hex_bytes: hex_encode(src_pub_key.toRaw()),
+          hex_bytes: blobToHex(src_pub_key.toRaw()),
           curve_type: "edwards25519",
         },
       ],
@@ -129,7 +130,7 @@ class Session extends RosettaClient {
     const submit_res = await this.transfer_post_combine(combine_res);
 
     assert(
-      hex_encode(transaction_hash(payloads_res)) ===
+      blobToHex(transaction_hash(payloads_res)) ===
         submit_res.transaction_identifier.hash
     );
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -129,7 +129,7 @@ class Session extends RosettaClient {
       count
     );
 
-    const combine_res = transfer_combine(src_key, payloads_res);
+    const combine_res = await transfer_combine(src_key, payloads_res);
 
     const submit_res = await this.transfer_post_combine(combine_res);
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,11 +1,6 @@
 const assert = require("assert").strict;
 const { RosettaClient } = require("@lunarhq/rosetta-ts-client");
-const {
-  key_to_pub_key,
-  pub_key_to_address,
-  address_to_hex,
-  hex_encode,
-} = require("./key.js");
+const { pub_key_to_address, address_to_hex, hex_encode } = require("./key.js");
 const { transfer_combine } = require("./construction_combine.js");
 const { transaction_hash } = require("./transaction_hash.js");
 
@@ -45,7 +40,7 @@ class Session extends RosettaClient {
 
   /**
    *
-   * @param {Buffer} src_pub_key
+   * @param {import("@dfinity/authentication").Ed25519PublicKey} src_pub_key
    * @param {Buffer} dest_addr
    * @param {BigInt} count
    * @returns {Promise<import("@lunarhq/rosetta-ts-client").ConstructionPayloadsResponse>}
@@ -94,7 +89,7 @@ class Session extends RosettaClient {
       metadata: (await this.metadata({ network_identifier: net_id })).metadata,
       public_keys: [
         {
-          hex_bytes: hex_encode(src_pub_key),
+          hex_bytes: hex_encode(src_pub_key.toRaw()),
           curve_type: "edwards25519",
         },
       ],
@@ -117,19 +112,19 @@ class Session extends RosettaClient {
 
   /**
    *
-   * @param {Buffer} src_key
+   * @param {import("@dfinity/authentication").Ed25519KeyIdentity} src_identity
    * @param {Buffer} dest_addr
    * @param {BigInt} count
    * @returns {Promise<import("@lunarhq/rosetta-ts-client").TransactionIdentifierResponse>}
    */
-  async transfer(src_key, dest_addr, count) {
+  async transfer(src_identity, dest_addr, count) {
     const payloads_res = await this.transfer_pre_combine(
-      key_to_pub_key(src_key),
+      src_identity.getPublicKey(),
       dest_addr,
       count
     );
 
-    const combine_res = await transfer_combine(src_key, payloads_res);
+    const combine_res = await transfer_combine(src_identity, payloads_res);
 
     const submit_res = await this.transfer_post_combine(combine_res);
 

--- a/lib/transaction_hash.js
+++ b/lib/transaction_hash.js
@@ -1,5 +1,5 @@
 const assert = require("assert").strict;
-const IDL = require("@dfinity/agent").IDL;
+const agent = require("@dfinity/agent");
 const { cbor_decode, cbor_encode } = require("./cbor.js");
 const { sha256 } = require("./hash.js");
 const {
@@ -8,21 +8,21 @@ const {
   principal_id_to_address,
 } = require("./key.js");
 
-const ICPTsType = IDL.Record({ doms: IDL.Nat64 });
+const ICPTsType = agent.IDL.Record({ doms: agent.IDL.Nat64 });
 
-const MemoType = IDL.Nat64;
+const MemoType = agent.IDL.Nat64;
 
-const AccountIdentifierType = IDL.Text;
+const AccountIdentifierType = agent.IDL.Text;
 
-const SubAccountType = IDL.Vec(IDL.Nat8);
+const SubAccountType = agent.IDL.Vec(agent.IDL.Nat8);
 
-const SendArgsType = IDL.Record({
+const SendArgsType = agent.IDL.Record({
   memo: MemoType,
   amount: ICPTsType,
   fee: ICPTsType,
-  from_subaccount: IDL.Opt(SubAccountType),
+  from_subaccount: agent.IDL.Opt(SubAccountType),
   to: AccountIdentifierType,
-  block_height: IDL.Opt(IDL.Nat64),
+  block_height: agent.IDL.Opt(agent.IDL.Nat64),
 });
 
 /**
@@ -43,7 +43,14 @@ function transaction_hash(payloads_res) {
             [
               2,
               new Map([
-                [0, address_to_hex(principal_id_to_address(update.sender))],
+                [
+                  0,
+                  address_to_hex(
+                    principal_id_to_address(
+                      agent.Principal.fromBlob(update.sender)
+                    )
+                  ),
+                ],
                 [1, send_args.to],
                 [2, new Map([[0, send_args.amount]])],
                 [3, new Map([[0, send_args.fee]])],
@@ -66,7 +73,7 @@ exports.transaction_hash = transaction_hash;
  * @returns {object}
  */
 function SendArgs_decode(buf) {
-  const arr = IDL.decode([SendArgsType], buf);
+  const arr = agent.IDL.decode([SendArgsType], buf);
   assert(arr.length === 1);
   const send_args = arr[0];
   return {

--- a/lib/transaction_hash.js
+++ b/lib/transaction_hash.js
@@ -2,11 +2,7 @@ const assert = require("assert").strict;
 const agent = require("@dfinity/agent");
 const { cbor_decode, cbor_encode } = require("./cbor.js");
 const { sha256 } = require("./hash.js");
-const {
-  address_to_hex,
-  hex_decode,
-  principal_id_to_address,
-} = require("./key.js");
+const { address_to_hex, principal_id_to_address } = require("./key.js");
 
 const ICPTsType = agent.IDL.Record({ doms: agent.IDL.Nat64 });
 
@@ -31,7 +27,9 @@ const SendArgsType = agent.IDL.Record({
  * @returns {Buffer}
  */
 function transaction_hash(payloads_res) {
-  const update = cbor_decode(hex_decode(payloads_res.unsigned_transaction));
+  const update = cbor_decode(
+    agent.blobFromHex(payloads_res.unsigned_transaction)
+  );
   assert(update.method_name === "send");
   const send_args = SendArgs_decode(update.arg);
   return sha256([

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@lunarhq/rosetta-ts-client": "^1.4.8-rc3",
         "cbor": "^7.0.4",
         "crc": "^3.8.0",
+        "js-sha256": "^0.9.0",
         "tweetnacl": "^1.0.3"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,11 @@
       "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dfinity/agent": "^0.6.26",
-        "@dfinity/authentication": "^0.6.24-lerna.0",
+        "@dfinity/agent": "0.6.26",
+        "@dfinity/authentication": "0.6.24-authentication.0",
         "@lunarhq/rosetta-ts-client": "^1.4.8-rc3",
         "cbor": "^7.0.4",
         "crc": "^3.8.0",
-        "rfc4648": "^1.4.0",
         "tweetnacl": "^1.0.3"
       }
     },
@@ -67,11 +66,11 @@
       }
     },
     "node_modules/@dfinity/authentication": {
-      "version": "0.6.24-lerna.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.6.24-lerna.0.tgz",
-      "integrity": "sha512-ye9bZjxHbd0r2vPWf5W7PGqIwNoPfvg9GUVxO0j1npqo8VIJ+w/gVbHh4epsGGEcZQCEUe2ZzHzmijFCfRaOEQ==",
+      "version": "0.6.24-authentication.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.6.24-authentication.0.tgz",
+      "integrity": "sha512-uzwKwgoXHpVkvjjzcjRGUbZysW7d3n6LxjthG8LLGLq5wpRzwenHE1vMSnl2e5NqonhdweK+FKBNyZJF01pMjg==",
       "dependencies": {
-        "@dfinity/agent": "^0.6.24-lerna.0",
+        "@dfinity/agent": "^0.6.24-authentication.0",
         "@types/crc": "^3.4.0",
         "@types/jest": "^24.0.18",
         "asn1.js": "^5.4.1",
@@ -5346,11 +5345,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/rfc4648": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.4.0.tgz",
-      "integrity": "sha512-3qIzGhHlMHA6PoT6+cdPKZ+ZqtxkIvg8DZGKA5z6PQ33/uuhoJ+Ws/D/J9rXW6gXodgH8QYlz2UCl+sdUDmNIg=="
-    },
     "node_modules/ripemd160": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
@@ -5572,11 +5566,11 @@
       }
     },
     "@dfinity/authentication": {
-      "version": "0.6.24-lerna.0",
-      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.6.24-lerna.0.tgz",
-      "integrity": "sha512-ye9bZjxHbd0r2vPWf5W7PGqIwNoPfvg9GUVxO0j1npqo8VIJ+w/gVbHh4epsGGEcZQCEUe2ZzHzmijFCfRaOEQ==",
+      "version": "0.6.24-authentication.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.6.24-authentication.0.tgz",
+      "integrity": "sha512-uzwKwgoXHpVkvjjzcjRGUbZysW7d3n6LxjthG8LLGLq5wpRzwenHE1vMSnl2e5NqonhdweK+FKBNyZJF01pMjg==",
       "requires": {
-        "@dfinity/agent": "^0.6.24-lerna.0",
+        "@dfinity/agent": "^0.6.24-authentication.0",
         "@types/crc": "^3.4.0",
         "@types/jest": "^24.0.18",
         "asn1.js": "^5.4.1",
@@ -9493,11 +9487,6 @@
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
-    },
-    "rfc4648": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.4.0.tgz",
-      "integrity": "sha512-3qIzGhHlMHA6PoT6+cdPKZ+ZqtxkIvg8DZGKA5z6PQ33/uuhoJ+Ws/D/J9rXW6gXodgH8QYlz2UCl+sdUDmNIg=="
     },
     "ripemd160": {
       "version": "2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dfinity/agent": "^0.6.25",
+        "@dfinity/agent": "^0.6.26",
+        "@dfinity/authentication": "^0.6.24-lerna.0",
         "@lunarhq/rosetta-ts-client": "^1.4.8-rc3",
         "cbor": "^7.0.4",
         "crc": "^3.8.0",
@@ -65,6 +66,27 @@
         "simple-cbor": "^0.4.1"
       }
     },
+    "node_modules/@dfinity/authentication": {
+      "version": "0.6.24-lerna.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.6.24-lerna.0.tgz",
+      "integrity": "sha512-ye9bZjxHbd0r2vPWf5W7PGqIwNoPfvg9GUVxO0j1npqo8VIJ+w/gVbHh4epsGGEcZQCEUe2ZzHzmijFCfRaOEQ==",
+      "dependencies": {
+        "@dfinity/agent": "^0.6.24-lerna.0",
+        "@types/crc": "^3.4.0",
+        "@types/jest": "^24.0.18",
+        "asn1.js": "^5.4.1",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.0.0",
+        "bip39": "^3.0.2",
+        "borc": "^2.1.1",
+        "buffer": "^5.4.3",
+        "buffer-pipe": "0.0.4",
+        "crc": "3.8.0",
+        "js-sha256": "0.9.0",
+        "simple-cbor": "^0.4.1",
+        "tweetnacl": "^1.0.1"
+      }
+    },
     "node_modules/@jest/types": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
@@ -82,6 +104,7 @@
       "version": "1.4.8-rc3",
       "resolved": "https://registry.npmjs.org/@lunarhq/rosetta-ts-client/-/rosetta-ts-client-1.4.8-rc3.tgz",
       "integrity": "sha512-mCqambUwDHqULJxrMPWxku8+6BphBxlC41NIFy788VxodciXW+8RP3mx5HHaTl1cS+Gab55sRcG3tuqmjuhddA==",
+      "license": "MIT",
       "dependencies": {
         "axios": "^0.21.0",
         "i": "^0.3.6",
@@ -188,6 +211,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "dependencies": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "node_modules/axios": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
@@ -230,6 +264,27 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/bip39": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.3.tgz",
+      "integrity": "sha512-P0dKrz4g0V0BjXfx7d9QNkJ/Txcz/k+hM9TnjqjUaXtuOfAvxXSw2rJw8DX0e3ZPwnK/IgDxoRqf0bvoVCqbMg==",
+      "dependencies": {
+        "@types/node": "11.11.6",
+        "create-hash": "^1.1.0",
+        "pbkdf2": "^3.0.9",
+        "randombytes": "^2.0.1"
+      }
+    },
+    "node_modules/bip39/node_modules/@types/node": {
+      "version": "11.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+      "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+    },
+    "node_modules/bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/borc": {
       "version": "2.1.2",
@@ -337,6 +392,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -361,6 +425,31 @@
       "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
       "dependencies": {
         "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "node_modules/debug": {
@@ -495,6 +584,19 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      },
       "engines": {
         "node": ">=4"
       }
@@ -702,6 +804,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "node_modules/meow": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
@@ -734,6 +846,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -5062,6 +5179,21 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
+    "node_modules/pbkdf2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+      "dependencies": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/prettier": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
@@ -5101,6 +5233,14 @@
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dependencies": {
+        "safe-buffer": "^5.1.0"
       }
     },
     "node_modules/react-is": {
@@ -5220,6 +5360,15 @@
       "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.4.0.tgz",
       "integrity": "sha512-3qIzGhHlMHA6PoT6+cdPKZ+ZqtxkIvg8DZGKA5z6PQ33/uuhoJ+Ws/D/J9rXW6gXodgH8QYlz2UCl+sdUDmNIg=="
     },
+    "node_modules/ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -5239,6 +5388,11 @@
         }
       ]
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
     "node_modules/semver": {
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -5251,6 +5405,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      },
+      "bin": {
+        "sha.js": "bin.js"
       }
     },
     "node_modules/simple-cbor": {
@@ -5323,6 +5489,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "node_modules/type-fest": {
       "version": "0.18.1",
@@ -5407,6 +5578,27 @@
         "crc": "3.8.0",
         "js-sha256": "0.9.0",
         "simple-cbor": "^0.4.1"
+      }
+    },
+    "@dfinity/authentication": {
+      "version": "0.6.24-lerna.0",
+      "resolved": "https://registry.npmjs.org/@dfinity/authentication/-/authentication-0.6.24-lerna.0.tgz",
+      "integrity": "sha512-ye9bZjxHbd0r2vPWf5W7PGqIwNoPfvg9GUVxO0j1npqo8VIJ+w/gVbHh4epsGGEcZQCEUe2ZzHzmijFCfRaOEQ==",
+      "requires": {
+        "@dfinity/agent": "^0.6.24-lerna.0",
+        "@types/crc": "^3.4.0",
+        "@types/jest": "^24.0.18",
+        "asn1.js": "^5.4.1",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.0.0",
+        "bip39": "^3.0.2",
+        "borc": "^2.1.1",
+        "buffer": "^5.4.3",
+        "buffer-pipe": "0.0.4",
+        "crc": "3.8.0",
+        "js-sha256": "0.9.0",
+        "simple-cbor": "^0.4.1",
+        "tweetnacl": "^1.0.1"
       }
     },
     "@jest/types": {
@@ -5520,6 +5712,17 @@
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
     },
+    "asn1.js": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+      "requires": {
+        "bn.js": "^4.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "safer-buffer": "^2.1.0"
+      }
+    },
     "axios": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
@@ -5542,6 +5745,29 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
       "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+    },
+    "bip39": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.3.tgz",
+      "integrity": "sha512-P0dKrz4g0V0BjXfx7d9QNkJ/Txcz/k+hM9TnjqjUaXtuOfAvxXSw2rJw8DX0e3ZPwnK/IgDxoRqf0bvoVCqbMg==",
+      "requires": {
+        "@types/node": "11.11.6",
+        "create-hash": "^1.1.0",
+        "pbkdf2": "^3.0.9",
+        "randombytes": "^2.0.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "11.11.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
+          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
+        }
+      }
+    },
+    "bn.js": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "borc": {
       "version": "2.1.2",
@@ -5608,6 +5834,15 @@
         "supports-color": "^5.3.0"
       }
     },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -5632,6 +5867,31 @@
       "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
       "requires": {
         "buffer": "^5.1.0"
+      }
+    },
+    "create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "requires": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "requires": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
       }
     },
     "debug": {
@@ -5722,6 +5982,16 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "hash-base": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+      "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "safe-buffer": "^5.2.0"
+      }
     },
     "hosted-git-info": {
       "version": "4.0.1",
@@ -5867,6 +6137,16 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.2.0.tgz",
       "integrity": "sha512-NAq0fCmZYGz9UFEQyndp7sisrow4GroyGeKluyKC/chuITZsPyOyC1UJZPJlVFImhXdROIP5xqouRLThT3BbpQ=="
     },
+    "md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
     "meow": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
@@ -5890,6 +6170,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
     },
     "minimist-options": {
       "version": "4.1.0",
@@ -9088,6 +9373,18 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
+    "pbkdf2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+      "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+      "requires": {
+        "create-hash": "^1.1.2",
+        "create-hmac": "^1.1.4",
+        "ripemd160": "^2.0.1",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
     "prettier": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
@@ -9113,6 +9410,14 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+    },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
     },
     "react-is": {
       "version": "16.13.1",
@@ -9208,10 +9513,24 @@
       "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.4.0.tgz",
       "integrity": "sha512-3qIzGhHlMHA6PoT6+cdPKZ+ZqtxkIvg8DZGKA5z6PQ33/uuhoJ+Ws/D/J9rXW6gXodgH8QYlz2UCl+sdUDmNIg=="
     },
+    "ripemd160": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+      "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "requires": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1"
+      }
+    },
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "7.3.5",
@@ -9219,6 +9538,15 @@
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "requires": {
         "lru-cache": "^6.0.0"
+      }
+    },
+    "sha.js": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "simple-cbor": {
@@ -9282,6 +9610,11 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
       "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA=="
+    },
+    "tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
     },
     "type-fest": {
       "version": "0.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,8 @@
         "@lunarhq/rosetta-ts-client": "^1.4.8-rc3",
         "cbor": "^7.0.4",
         "crc": "^3.8.0",
-        "node-forge": "^0.10.0",
-        "rfc4648": "^1.4.0"
+        "rfc4648": "^1.4.0",
+        "tweetnacl": "^1.0.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -104,7 +104,6 @@
       "version": "1.4.8-rc3",
       "resolved": "https://registry.npmjs.org/@lunarhq/rosetta-ts-client/-/rosetta-ts-client-1.4.8-rc3.tgz",
       "integrity": "sha512-mCqambUwDHqULJxrMPWxku8+6BphBxlC41NIFy788VxodciXW+8RP3mx5HHaTl1cS+Gab55sRcG3tuqmjuhddA==",
-      "license": "MIT",
       "dependencies": {
         "axios": "^0.21.0",
         "i": "^0.3.6",
@@ -882,14 +881,6 @@
       },
       "engines": {
         "node": ">= 10.13"
-      }
-    },
-    "node_modules/node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/nofilter": {
@@ -6201,11 +6192,6 @@
         "lodash.set": "^4.3.2",
         "propagate": "^2.0.0"
       }
-    },
-    "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
     },
     "nofilter": {
       "version": "2.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@dfinity/agent": "0.6.26",
+        "@dfinity/agent": "0.6.28",
         "@dfinity/authentication": "0.6.24-authentication.0",
         "@lunarhq/rosetta-ts-client": "^1.4.8-rc3",
         "cbor": "^7.0.4",
@@ -50,13 +50,13 @@
       }
     },
     "node_modules/@dfinity/agent": {
-      "version": "0.6.26",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.6.26.tgz",
-      "integrity": "sha512-zAIUcunt+NoTyGXgVLmW5pYZ9V+c1e7F8bPP5MIFYMKpDpzQvvR+uRotM+OoBkBUxkyyK1z+2Mem3V8dHO6BJg==",
+      "version": "0.6.28",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.6.28.tgz",
+      "integrity": "sha512-B/iHSbcGWptmXU2Vea+HwPtn6AdJCFYqv+1RpN6LOq5nEPJL+8VZwFaxig60AqzP8/qb0HZNzqg/U60rxc3cvg==",
       "dependencies": {
         "@types/crc": "^3.4.0",
         "@types/jest": "^24.0.18",
-        "base32.js": "^0.1.0",
+        "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
         "borc": "^2.1.1",
         "buffer": "^5.4.3",
@@ -235,6 +235,14 @@
       "integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI=",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/base64-js": {
@@ -5550,13 +5558,13 @@
       "integrity": "sha512-sJpx3F5xcVV/9jNYJQtvimo4Vfld/nD3ph+ZWtQzZ03Zo8rJC7QKQTRcIGS13Rcz80DwFNthCWMrd58vpY4ZAQ=="
     },
     "@dfinity/agent": {
-      "version": "0.6.26",
-      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.6.26.tgz",
-      "integrity": "sha512-zAIUcunt+NoTyGXgVLmW5pYZ9V+c1e7F8bPP5MIFYMKpDpzQvvR+uRotM+OoBkBUxkyyK1z+2Mem3V8dHO6BJg==",
+      "version": "0.6.28",
+      "resolved": "https://registry.npmjs.org/@dfinity/agent/-/agent-0.6.28.tgz",
+      "integrity": "sha512-B/iHSbcGWptmXU2Vea+HwPtn6AdJCFYqv+1RpN6LOq5nEPJL+8VZwFaxig60AqzP8/qb0HZNzqg/U60rxc3cvg==",
       "requires": {
         "@types/crc": "^3.4.0",
         "@types/jest": "^24.0.18",
-        "base32.js": "^0.1.0",
+        "base64-arraybuffer": "^0.2.0",
         "bignumber.js": "^9.0.0",
         "borc": "^2.1.1",
         "buffer": "^5.4.3",
@@ -5721,6 +5729,11 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/base32.js/-/base32.js-0.1.0.tgz",
       "integrity": "sha1-tYLexpPC8R6JPPBk7mrFthMaIgI="
+    },
+    "base64-arraybuffer": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.2.0.tgz",
+      "integrity": "sha512-7emyCsu1/xiBXgQZrscw/8KPRT44I4Yq9Pe6EGs3aPRTsWuggML1/1DTuZUuIaJPIm1FTDUVXl4x/yW8s0kQDQ=="
     },
     "base64-js": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -19,12 +19,11 @@
   },
   "homepage": "https://github.com/dfinity-lab/rosetta-client",
   "dependencies": {
-    "@dfinity/agent": "^0.6.26",
-    "@dfinity/authentication": "^0.6.24-lerna.0",
+    "@dfinity/agent": "0.6.26",
+    "@dfinity/authentication": "0.6.24-authentication.0",
     "@lunarhq/rosetta-ts-client": "^1.4.8-rc3",
     "cbor": "^7.0.4",
     "crc": "^3.8.0",
-    "rfc4648": "^1.4.0",
     "tweetnacl": "^1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "homepage": "https://github.com/dfinity-lab/rosetta-client",
   "dependencies": {
-    "@dfinity/agent": "^0.6.25",
+    "@dfinity/agent": "^0.6.26",
+    "@dfinity/authentication": "^0.6.24-lerna.0",
     "@lunarhq/rosetta-ts-client": "^1.4.8-rc3",
     "cbor": "^7.0.4",
     "crc": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@lunarhq/rosetta-ts-client": "^1.4.8-rc3",
     "cbor": "^7.0.4",
     "crc": "^3.8.0",
-    "node-forge": "^0.10.0",
-    "rfc4648": "^1.4.0"
+    "rfc4648": "^1.4.0",
+    "tweetnacl": "^1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@lunarhq/rosetta-ts-client": "^1.4.8-rc3",
     "cbor": "^7.0.4",
     "crc": "^3.8.0",
+    "js-sha256": "^0.9.0",
     "tweetnacl": "^1.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/dfinity-lab/rosetta-client",
   "dependencies": {
-    "@dfinity/agent": "0.6.26",
+    "@dfinity/agent": "0.6.28",
     "@dfinity/authentication": "0.6.24-authentication.0",
     "@lunarhq/rosetta-ts-client": "^1.4.8-rc3",
     "cbor": "^7.0.4",

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,6 @@
-const { hex_decode, address_from_hex, Chain, Session } = require("../index.js");
 const { inspect } = require("util");
+const { Ed25519KeyIdentity } = require("@dfinity/authentication");
+const { hex_decode, address_from_hex, Chain, Session } = require("../index.js");
 
 (async () => {
   const session = new Session({ baseUrl: "http://localhost:8080" });
@@ -7,8 +8,10 @@ const { inspect } = require("util");
 
   try {
     let submit_res = await session.transfer(
-      hex_decode(
-        "093c3e2191be336f246259769041dd75b326143746b2ca97cb0f66273a366ba5ae7c3e96d49d7e5b1f74ce1e8ff640957c3ba4d7199f463a9fcff4c68b19f5e3"
+      Ed25519KeyIdentity.fromSecretKey(
+        hex_decode(
+          "093c3e2191be336f246259769041dd75b326143746b2ca97cb0f66273a366ba5ae7c3e96d49d7e5b1f74ce1e8ff640957c3ba4d7199f463a9fcff4c68b19f5e3"
+        )
       ),
       address_from_hex(
         "1e1838071cb875e59c1da64af5e04951bb3c1e94c1285bf9ff7480a645e1aa56"

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,11 @@
 const { inspect } = require("util");
-const { blobFromHex } = require("@dfinity/agent");
-const { Ed25519KeyIdentity } = require("@dfinity/authentication");
-const { address_from_hex, Chain, Session } = require("../index.js");
+const {
+  Ed25519KeyIdentity,
+  blobFromHex,
+  address_from_hex,
+  Chain,
+  Session,
+} = require("../index.js");
 
 (async () => {
   const session = new Session({ baseUrl: "http://localhost:8080" });

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 const { inspect } = require("util");
+const { blobFromHex } = require("@dfinity/agent");
 const { Ed25519KeyIdentity } = require("@dfinity/authentication");
-const { hex_decode, address_from_hex, Chain, Session } = require("../index.js");
+const { address_from_hex, Chain, Session } = require("../index.js");
 
 (async () => {
   const session = new Session({ baseUrl: "http://localhost:8080" });
@@ -9,7 +10,7 @@ const { hex_decode, address_from_hex, Chain, Session } = require("../index.js");
   try {
     let submit_res = await session.transfer(
       Ed25519KeyIdentity.fromSecretKey(
-        hex_decode(
+        blobFromHex(
           "093c3e2191be336f246259769041dd75b326143746b2ca97cb0f66273a366ba5ae7c3e96d49d7e5b1f74ce1e8ff640957c3ba4d7199f463a9fcff4c68b19f5e3"
         )
       ),


### PR DESCRIPTION
This PR uses `@dfinity/agent` & `@dfinity/authentication` to replace some internal logic that we used to roll ourselves or rely on other 3rd party dependencies:

* Shaved off a lot of redundant logic. Remove `node-forge` and `rfc4648` dependency.
* Various public API that previously takes plain `Buffer` for private/public keys now takes `Ed25519KeyIdentity` for private keys and `Ed25519PublicKey` for public keys.
* The offline `transfer_combine` function is now async since the underlying `sign()` logic is async.
* We monkey-patch `Ed25519KeyIdentity` a little bit by setting the `fromSecretKey` method if it's not present yet. This should be removed when a usable new version of `@dfinity/authentication` is out.
* Some additional classes and functions in `@dfinity/agent` & `@dfinity/authentication` are re-exported here.
* Use `js-sha256` for hashing instead of `crypto`. This will improve browser compatibility.
* The documentation in `README` has been updated.