### PR TITLE
Relax exchanges timeout to 5min

### DIFF
--- a/test/test-exchanges.js
+++ b/test/test-exchanges.js
@@ -52,7 +52,7 @@ function nanos_since_unix_epoch() {
 
     const submit_res = await session.transfer_post_combine(combine_res);
 
-    await new Promise((resolve) => setTimeout(resolve, 10000));
+    await new Promise((resolve) => setTimeout(resolve, 5 * 60 * 1000));
 
     let tx_res = await session.transactions({
       network_identifier: await session.network_identifier,


### PR DESCRIPTION
Two major kinds of errors we get when transferring on exchanges: 1. 500 errors 2. `/search/transactions` returns 0 results. I suspect the later is due to not enough time for `ic-rosetta-api` to catch up, so better relax the timeout a bit to see if that still occurs.