### PR TITLE
Bikeshedding before `0.5.2` release

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -132,7 +132,8 @@ jobs:
             --canister-id $(jq -r .ledger.local .dfx/local/canister_ids.json) \
             --ic-url http://127.0.0.1:8000 \
             --address 127.0.0.1 \
-            --port 8080 &
+            --port 8080 \
+            --store-type in-memory &
 
           popd
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -70,7 +70,7 @@ jobs:
           - 12
           - 10
         sdk_ver:
-          - 0.7.0
+          - 0.7.1
     steps:
 
       - name: checkout
@@ -119,11 +119,13 @@ jobs:
           dfx start \
             --background \
             --clean \
-            --host 127.0.0.1:8000
+            --host 127.0.0.1:8000 \
+            --no-artificial-delay
 
           dfx deploy \
             --argument "record { minting_account = \"ea2d973e67dcbcb00f1cfb36d05d600eef68c7513c18dac8ef52d165c1d38c36\"; initial_values = vec { record { \"a8a3746fca2b69ee144224ab735b0c0f1977d3aa44a97c75240da7ab05becea4\"; record { e8s = 18446744073709551615 } } }; max_message_size_bytes = null; transaction_window = null; archive_options = null; send_whitelist = vec {}}" \
             --network=local \
+            --no-wallet \
             ledger
 
           ic-rosetta-api \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# `0.5.2`
+
+- Add `seed_from_pem` to support loading a private key from a PEM file generated
+  by `dfx identity` command. (#42)
+
+# `0.5.1`
+
+- Fix `signed_transaction_decode` to work with upstream changes. (#34)
+
+# `0.5.0`
+
+- Fix a quadratic slowdown in offline combine implementation. (#33)
+- Misc documentation fixes. (#33)
+
 # `0.4.0`
 
 - Add support for flexible ingress expiry. (#27)


### PR DESCRIPTION
* Fasten local deployment a little bit
* Add missing `CHANGELOG` entries