### PR TITLE
More strict address verification

### DIFF
--- a/lib/key.js
+++ b/lib/key.js
@@ -158,12 +158,12 @@ exports.pub_key_to_address = pub_key_to_address;
  * @returns {Buffer}
  */
 function address_from_hex(hex_str) {
-  assert(hex_str.length === 64);
+  assert.equal(hex_str.length, 64, "invalid input hex length");
   const buf = bufferFromArrayBufferView(blobFromHex(hex_str));
-  assert(buf.byteLength === 32);
+  assert.equal(buf.byteLength, 32, "invalid address length in bytes");
   const ret = crc32_del(buf);
   const hex_str2 = address_to_hex(ret);
-  assert(hex_str === hex_str2);
+  assert.equal(hex_str.toLowerCase(), hex_str2.toLowerCase(), "dencode/encode roundtrip changes the address");
   return ret;
 }
 

--- a/lib/key.js
+++ b/lib/key.js
@@ -158,9 +158,13 @@ exports.pub_key_to_address = pub_key_to_address;
  * @returns {Buffer}
  */
 function address_from_hex(hex_str) {
+  assert(hex_str.length === 64);
   const buf = bufferFromArrayBufferView(blobFromHex(hex_str));
   assert(buf.byteLength === 32);
-  return crc32_del(buf);
+  const ret = crc32_del(buf);
+  const hex_str2 = address_to_hex(ret);
+  assert(hex_str === hex_str2);
+  return ret;
 }
 
 exports.address_from_hex = address_from_hex;

--- a/test/test-local.js
+++ b/test/test-local.js
@@ -7,6 +7,7 @@ const {
   key_new,
   key_to_pub_key,
   pub_key_to_address,
+  address_from_hex,
   seed_from_pem,
   signed_transaction_decode,
   transfer_combine,
@@ -21,6 +22,20 @@ function nanos_since_unix_epoch() {
 
 (async () => {
   const session = new Session({ baseUrl: "http://localhost:8080" });
+
+  // a valid hex
+  address_from_hex("674c4e1c52807c912316c97e127cd4583883dbc4040922e4cc19ce8ce6ab0101");
+
+  // an invalid hex which gets converted to the above address
+  assert.throws(() => {
+          try {
+              address_from_hex("674c4e1c52807c912316c97e127cd4583883dbc4040922e4cc19ce8ce6ab011z")
+          } catch (err) {
+              throw Error("address_from_hex failed");
+          }
+      },
+      Error("address_from_hex failed")
+  );
 
   try {
     const src_key = key_new(

--- a/test/test-local.js
+++ b/test/test-local.js
@@ -28,14 +28,15 @@ function nanos_since_unix_epoch() {
 
   // an invalid hex which gets converted to the above address
   assert.throws(() => {
-          try {
-              address_from_hex("674c4e1c52807c912316c97e127cd4583883dbc4040922e4cc19ce8ce6ab011z")
-          } catch (err) {
-              throw Error("address_from_hex failed");
-          }
-      },
-      Error("address_from_hex failed")
-  );
+     address_from_hex("674c4e1c52807c912316c97e127cd4583883dbc4040922e4cc19ce8ce6ab011z")
+  });
+
+  assert.throws(() => {
+     address_from_hex("ab1")
+  });
+  assert.throws(() => {
+     address_from_hex("this is not hex")
+  });
 
   try {
     const src_key = key_new(


### PR DESCRIPTION
This change improves the input validation of `address_from_hex` function:
  1. We check that the address length is correct.
  2. We check the roundtrip property: the hex parsing function can return garbage sometimes, so we check that converting its output back to hex produces the same string.