### PR TITLE
Add staking support

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -66,6 +66,13 @@ jobs:
             --http-port 2053 \
             --initial-notary-delay-millis 600 &
 
+      - name: init-ic
+        run: |
+          ${{ runner.temp }}/ic/artifacts/release/ic-nns-init \
+            --initialize-ledger-with-test-accounts db0bd98f8268213b0b74b238c1611848830f47a5c416ae27ae4b80cde7216c57 \
+            --url http://127.0.0.1:2053 \
+            --wasm-dir ${{ runner.temp }}/ic/artifacts/canisters
+
       - name: start-rosetta
         run: |
           pushd ${{ runner.temp }}/ic/rs/rosetta-api
@@ -75,13 +82,6 @@ jobs:
             --port 8080 \
             --store-type sqlite-in-memory &
           popd
-
-      - name: init-ic
-        run: |
-          ${{ runner.temp }}/ic/artifacts/release/ic-nns-init \
-            --initialize-ledger-with-test-accounts db0bd98f8268213b0b74b238c1611848830f47a5c416ae27ae4b80cde7216c57 \
-            --url http://127.0.0.1:2053 \
-            --wasm-dir ${{ runner.temp }}/ic/artifacts/canisters
 
       - name: setup-node
         uses: actions/setup-node@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -103,6 +103,7 @@ jobs:
           sleep 10
 
           node --unhandled-rejections=strict ./test/test-local.js
+          node --unhandled-rejections=strict ./test/test-staking.js
 
       - name: artifact-upload
         uses: actions/upload-artifact@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -9,31 +9,17 @@ on:
 jobs:
 
   integration-test-local:
-    name: integration-test-local-node-${{ matrix.node }}-sdk-${{ matrix.sdk_ver }}
+    name: integration-test-local-node-${{ matrix.node }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         node:
-          - 17
+          - 18
           - 16
           - 14
           - 12
-        sdk_ver:
-          - 0.9.3
     steps:
-
-      - name: setup-dfx
-        run: |
-          mkdir -p ~/.local/bin
-          echo ~/.local/bin >> $GITHUB_PATH
-          curl -L https://sdk.dfinity.org/downloads/dfx/${{ matrix.sdk_ver }}/x86_64-linux/dfx-${{ matrix.sdk_ver }}.tar.gz | tar xz --strip-components 1 -C ~/.local/bin
-
-      - name: start-ic
-        run: |
-          pushd ${{ runner.temp }}
-          dfx replica --port 2053 &
-          popd
 
       - name: checkout-ic
         run: |
@@ -68,6 +54,17 @@ jobs:
           done
 
           popd
+
+      - name: start-ic
+        run: |
+          exec ${{ runner.temp }}/ic/artifacts/release/ic-starter \
+            --replica-path ${{ runner.temp }}/ic/artifacts/release/replica \
+            --state-dir "$(mktemp -d)" \
+            --create-funds-whitelist "*" \
+            --consensus-pool-backend rocksdb \
+            --subnet-type system \
+            --http-port 2053 \
+            --initial-notary-delay-millis 600 &
 
       - name: start-rosetta
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -38,26 +38,24 @@ jobs:
 
           gitlab-ci/src/artifacts/rclone_download.py \
             --latest-to \
+            --mark-executable \
+            --out=artifacts/release \
             --remote-path=release \
-            --out=artifacts/release
+            --unpack
           gitlab-ci/src/artifacts/rclone_download.py \
             --latest-to \
+            --out=artifacts/canisters \
             --remote-path=canisters \
-            --out=artifacts/canisters
-
-          for f in artifacts/release/*.gz; do
-            gunzip $f
-            chmod +x artifacts/release/$(basename $f .gz)
-          done
-          for f in artifacts/canisters/*.gz; do
-            gunzip $f
-          done
+            --unpack
 
           popd
 
       - name: start-ic
         run: |
-          exec ${{ runner.temp }}/ic/artifacts/release/ic-starter \
+          env \
+            RUST_BACKTRACE=1 \
+            RUST_MIN_STACK=8192000 \
+            ${{ runner.temp }}/ic/artifacts/release/ic-starter \
             --replica-path ${{ runner.temp }}/ic/artifacts/release/replica \
             --state-dir "$(mktemp -d)" \
             --create-funds-whitelist "*" \
@@ -66,9 +64,13 @@ jobs:
             --http-port 2053 \
             --initial-notary-delay-millis 600 &
 
+      - name: checkout
+        uses: actions/checkout@v3
+
       - name: init-ic
         run: |
           ${{ runner.temp }}/ic/artifacts/release/ic-nns-init \
+            --initial-neurons test/neurons.csv \
             --initialize-ledger-with-test-accounts db0bd98f8268213b0b74b238c1611848830f47a5c416ae27ae4b80cde7216c57 \
             --url http://127.0.0.1:2053 \
             --wasm-dir ${{ runner.temp }}/ic/artifacts/canisters
@@ -84,13 +86,10 @@ jobs:
           popd
 
       - name: setup-node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
-
-      - name: checkout
-        uses: actions/checkout@v2
 
       - name: test
         run: |
@@ -101,9 +100,10 @@ jobs:
 
           node --unhandled-rejections=strict ./test/test-local.js
           node --unhandled-rejections=strict ./test/test-staking.js
+          node --unhandled-rejections=strict ./test/test-staking-merge-spawn.js
 
       - name: artifact-upload
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ matrix.node == 14 }}
         with:
           name: dist

--- a/.github/workflows/protobuf-check.yml
+++ b/.github/workflows/protobuf-check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: checkout-ic
         run: |
@@ -23,12 +23,14 @@ jobs:
           mv ic-master ic
           popd
 
-      - name: setup-nix
-        uses: cachix/install-nix-action@v16
-
       - name: setup-protoc
         run: |
-          nix profile install nixpkgs#protobuf3_13
+          mkdir ~/.local
+          pushd ${{ runner.temp }}
+          curl -L https://github.com/protocolbuffers/protobuf/releases/download/v3.18.1/protoc-3.18.1-linux-x86_64.zip -O
+          unzip protoc-3.18.1-linux-x86_64.zip -d ~/.local
+          popd
+          echo ~/.local/bin >> $GITHUB_PATH
 
       - name: check
         run: |

--- a/autogen/ic_base_types/pb/v1/types_pb.js
+++ b/autogen/ic_base_types/pb/v1/types_pb.js
@@ -2,11 +2,14 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;

--- a/autogen/ic_ledger/pb/v1/types_pb.js
+++ b/autogen/ic_ledger/pb/v1/types_pb.js
@@ -2,11 +2,14 @@
 /**
  * @fileoverview
  * @enhanceable
+ * @suppress {missingRequire} reports error on implicit type usages.
  * @suppress {messageConventions} JS Compiler reports an error if a variable or
  *     field starts with 'MSG_' and isn't a translatable message.
  * @public
  */
 // GENERATED CODE -- DO NOT EDIT!
+/* eslint-disable */
+// @ts-nocheck
 
 var jspb = require('google-protobuf');
 var goog = jspb;

--- a/lib/key.js
+++ b/lib/key.js
@@ -134,7 +134,11 @@ const ACCOUNT_DOMAIN_SEPERATOR = Buffer.from("\x0Aaccount-id");
  * @returns {Buffer}
  */
 function principal_id_to_address(pid) {
-  return sha224([ACCOUNT_DOMAIN_SEPERATOR, pid.toUint8Array(), SUB_ACCOUNT_ZERO]);
+  return sha224([
+    ACCOUNT_DOMAIN_SEPERATOR,
+    pid.toUint8Array(),
+    SUB_ACCOUNT_ZERO,
+  ]);
 }
 
 exports.principal_id_to_address = principal_id_to_address;
@@ -153,6 +157,17 @@ function pub_key_to_address(pub_key) {
 exports.pub_key_to_address = pub_key_to_address;
 
 /**
+ * Given a public key, generate the principal id string.
+ * @param {Buffer} pub_key
+ * @returns {string}
+ */
+function pub_key_to_principal_id(pub_key) {
+  return Principal.selfAuthenticating(pub_key_to_der(pub_key)).toText();
+}
+
+exports.pub_key_to_principal_id = pub_key_to_principal_id;
+
+/**
  *
  * @param {string} hex_str
  * @returns {Buffer}
@@ -163,7 +178,11 @@ function address_from_hex(hex_str) {
   assert.equal(buf.byteLength, 32, "invalid address length in bytes");
   const ret = crc32_del(buf);
   const hex_str2 = address_to_hex(ret);
-  assert.equal(hex_str.toLowerCase(), hex_str2.toLowerCase(), "dencode/encode roundtrip changes the address");
+  assert.equal(
+    hex_str.toLowerCase(),
+    hex_str2.toLowerCase(),
+    "dencode/encode roundtrip changes the address"
+  );
   return ret;
 }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -622,6 +622,10 @@ class Session {
     };
 
     if (!src_pub_key) src_pub_key = hot_pub_key;
+    const src_pub_key_obj = {
+      hex_bytes: blobToHex(src_pub_key),
+      curve_type: "edwards25519",
+    };
     const src_account = {
       address: address_to_hex(pub_key_to_address(src_pub_key)),
     };
@@ -637,6 +641,7 @@ class Session {
             topic: topic,
             followees: followees,
             neuron_index: neuron_idx,
+            controller: { public_key: src_pub_key_obj },
           },
         },
       ],
@@ -645,6 +650,92 @@ class Session {
     });
 
     const submit_res = await this.combine_submit(hot_key, payloads_res);
+
+    return submit_res;
+  }
+
+  async neuron_spawn(
+    src_key,
+    neuron_idx,
+    spawned_neuron_pub_key,
+    spawned_neuron_idx,
+    opts = {}
+  ) {
+    const net_id = await this.network_identifier;
+
+    const src_pub_key = key_to_pub_key(src_key);
+    const src_pub_key_obj = {
+      hex_bytes: blobToHex(src_pub_key),
+      curve_type: "edwards25519",
+    };
+    const src_account = {
+      address: address_to_hex(pub_key_to_address(src_pub_key)),
+    };
+
+    if (!spawned_neuron_pub_key) spawned_neuron_pub_key = src_pub_key;
+    const spawned_neuron_pub_key_obj = {
+      hex_bytes: blobToHex(spawned_neuron_pub_key),
+      curve_type: "edwards25519",
+    };
+
+    const payloads_res = await this.payloads({
+      network_identifier: net_id,
+      operations: [
+        {
+          operation_identifier: { index: 0 },
+          type: "SPAWN",
+          account: src_account,
+          metadata: {
+            neuron_index: neuron_idx,
+            controller: { public_key: spawned_neuron_pub_key_obj },
+            spawned_neuron_index: spawned_neuron_idx,
+          },
+        },
+      ],
+      metadata: opts,
+      public_keys: [src_pub_key_obj],
+    });
+
+    const submit_res = await this.combine_submit(src_key, payloads_res);
+
+    return submit_res;
+  }
+
+  async neuron_merge(
+    src_key,
+    neuron_idx,
+    percentage_to_merge = 100,
+    opts = {}
+  ) {
+    const net_id = await this.network_identifier;
+
+    const src_pub_key = key_to_pub_key(src_key);
+    const src_account = {
+      address: address_to_hex(pub_key_to_address(src_pub_key)),
+    };
+    const src_pub_key_obj = {
+      hex_bytes: blobToHex(src_pub_key),
+      curve_type: "edwards25519",
+    };
+
+    const payloads_res = await this.payloads({
+      network_identifier: net_id,
+      operations: [
+        {
+          operation_identifier: { index: 0 },
+          type: "MERGE_MATURITY",
+          account: src_account,
+          metadata: {
+            neuron_index: neuron_idx,
+            percentage_to_merge: percentage_to_merge,
+          },
+        },
+      ],
+      metadata: opts,
+      public_keys: [src_pub_key_obj],
+    });
+
+    const submit_res = await this.combine_submit(src_key, payloads_res);
 
     return submit_res;
   }

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,7 +1,14 @@
-const { blobToHex } = require("./blob");
+const { blobFromHex, blobToHex } = require("./blob");
 const axios = require("axios");
 const JSONbig = require("json-bigint")({ strict: true, useNativeBigInt: true });
-const { key_to_pub_key, pub_key_to_address, address_to_hex } = require("./key");
+const {
+  key_sign,
+  key_to_pub_key,
+  pub_key_to_address,
+  pub_key_to_principal_id,
+  address_from_hex,
+  address_to_hex,
+} = require("./key");
 const { transfer_combine } = require("./construction_combine");
 
 class Session {
@@ -34,7 +41,9 @@ class Session {
     const suggested_fee = this.network_identifier
       .then((net_id) => this.metadata({ network_identifier: net_id }))
       .then((res) =>
-        res.suggested_fee.find((fee) => fee.currency.symbol === (params.symbol || "ICP"))
+        res.suggested_fee.find(
+          (fee) => fee.currency.symbol === (params.symbol || "ICP")
+        )
       );
 
     /**
@@ -229,6 +238,366 @@ class Session {
     const combine_res = transfer_combine(src_key, payloads_res);
 
     const submit_res = await this.transfer_post_combine(combine_res);
+
+    return submit_res;
+  }
+
+  /**
+   *
+   * @param {Buffer} src_key
+   * @param {ConstructionPayloadsResponse} payloads_res
+   * @returns {Promise<TransactionIdentifierResponse>}
+   */
+  async combine_submit(src_key, payloads_res) {
+    const net_id = await this.network_identifier;
+
+    const src_pub_key = key_to_pub_key(src_key);
+    const src_pub_key_obj = {
+      hex_bytes: blobToHex(src_pub_key),
+      curve_type: "edwards25519",
+    };
+
+    const combine_res = await this.combine({
+      network_identifier: net_id,
+      signatures: payloads_res.payloads.map((p) => ({
+        signing_payload: p,
+        public_key: src_pub_key_obj,
+        signature_type: "ed25519",
+        hex_bytes: blobToHex(key_sign(src_key, blobFromHex(p.hex_bytes))),
+      })),
+      unsigned_transaction: payloads_res.unsigned_transaction,
+    });
+
+    const submit_res = await this.transfer_post_combine(combine_res);
+    return submit_res;
+  }
+
+  /**
+   *
+   * @param {Buffer} src_pub_key
+   * @param {bigint?} neuron_idx
+   * @returns {Promise<Buffer>}
+   */
+  async neuron_address(src_pub_key, neuron_idx) {
+    const net_id = await this.network_identifier;
+
+    const derive_res = await this.derive({
+      network_identifier: net_id,
+      public_key: {
+        hex_bytes: blobToHex(src_pub_key),
+        curve_type: "edwards25519",
+      },
+      metadata: {
+        account_type: "neuron",
+        neuron_index: neuron_idx,
+      },
+    });
+
+    return address_from_hex(derive_res.account_identifier.address);
+  }
+
+  /**
+   *
+   * @param {Buffer} src_pub_key
+   * @param {bigint} neuron_idx
+   * @returns {Promise<AccountBalanceResponse>}
+   */
+  async neuron_public_info(src_pub_key, neuron_idx) {
+    const net_id = await this.network_identifier;
+
+    const src_pub_key_obj = {
+      hex_bytes: blobToHex(src_pub_key),
+      curve_type: "edwards25519",
+    };
+
+    const neuron_addr = await this.neuron_address(src_pub_key, neuron_idx);
+
+    const balance_res = await this.accountBalance({
+      network_identifier: net_id,
+      account_identifier: {
+        address: address_to_hex(neuron_addr),
+      },
+      metadata: {
+        account_type: "neuron",
+        neuron_index: neuron_idx,
+        public_key: src_pub_key_obj,
+      },
+    });
+
+    return balance_res;
+  }
+
+  /**
+   *
+   * @param {Buffer} hot_key
+   * @param {bigint} neuron_idx
+   * @param {Buffer?} src_pub_key
+   * @param {object?} opts
+   * @returns {Promise<TransactionIdentifierResponse>}
+   */
+  async neuron_protected_info(hot_key, neuron_idx, src_pub_key, opts = {}) {
+    const net_id = await this.network_identifier;
+
+    const hot_pub_key = key_to_pub_key(hot_key);
+    const hot_pub_key_obj = {
+      hex_bytes: blobToHex(hot_pub_key),
+      curve_type: "edwards25519",
+    };
+
+    if (!src_pub_key) src_pub_key = hot_pub_key;
+    const src_account = {
+      address: address_to_hex(pub_key_to_address(src_pub_key)),
+    };
+
+    const payloads_res = await this.payloads({
+      network_identifier: net_id,
+      operations: [
+        {
+          operation_identifier: { index: 0 },
+          type: "NEURON_INFO",
+          account: src_account,
+          metadata: {
+            neuron_index: neuron_idx,
+            controller: pub_key_to_principal_id(src_pub_key),
+          },
+        },
+      ],
+      metadata: opts,
+      public_keys: [hot_pub_key_obj],
+    });
+
+    const submit_res = await this.combine_submit(hot_key, payloads_res);
+
+    return submit_res;
+  }
+
+  /**
+   *
+   * @param {Buffer} src_key
+   * @param {bigint} neuron_idx
+   * @param {bigint} count
+   * @param {bigint?} max_fee
+   * @param {object?} opts
+   * @returns {Promise<TransactionIdentifierResponse>}
+   */
+  async neuron_charge(
+    src_key,
+    neuron_idx,
+    count,
+    max_fee = undefined,
+    opts = {}
+  ) {
+    const src_pub_key = key_to_pub_key(src_key);
+    const neuron_addr = await this.neuron_address(src_pub_key, neuron_idx);
+    const submit_res = await this.transfer(
+      src_key,
+      neuron_addr,
+      count,
+      max_fee,
+      opts
+    );
+    return submit_res;
+  }
+
+  /**
+   *
+   * @param {Buffer} src_key
+   * @param {bigint?} neuron_idx
+   * @param {object?} opts
+   * @returns {Promise<TransactionIdentifierResponse>}
+   */
+  async neuron_stake(src_key, neuron_idx, opts = {}) {
+    const net_id = await this.network_identifier;
+
+    const src_pub_key = key_to_pub_key(src_key);
+    const src_account = {
+      address: address_to_hex(pub_key_to_address(src_pub_key)),
+    };
+    const src_pub_key_obj = {
+      hex_bytes: blobToHex(src_pub_key),
+      curve_type: "edwards25519",
+    };
+
+    const payloads_res = await this.payloads({
+      network_identifier: net_id,
+      operations: [
+        {
+          operation_identifier: { index: 0 },
+          type: "STAKE",
+          account: src_account,
+          metadata: {
+            neuron_index: neuron_idx,
+          },
+        },
+      ],
+      metadata: opts,
+      public_keys: [src_pub_key_obj],
+    });
+
+    const submit_res = await this.combine_submit(src_key, payloads_res);
+
+    return submit_res;
+  }
+
+  /**
+   *
+   * @param {Buffer} src_key
+   * @param {bigint} neuron_idx
+   * @param {bigint} dissolve_time_utc_seconds
+   * @param {object?} opts
+   * @returns {Promise<TransactionIdentifierResponse>}
+   */
+  async neuron_set_dissolve_timestamp(
+    src_key,
+    neuron_idx,
+    dissolve_time_utc_seconds,
+    opts = {}
+  ) {
+    const net_id = await this.network_identifier;
+
+    const src_pub_key = key_to_pub_key(src_key);
+    const src_account = {
+      address: address_to_hex(pub_key_to_address(src_pub_key)),
+    };
+    const src_pub_key_obj = {
+      hex_bytes: blobToHex(src_pub_key),
+      curve_type: "edwards25519",
+    };
+
+    const payloads_res = await this.payloads({
+      network_identifier: net_id,
+      operations: [
+        {
+          operation_identifier: { index: 0 },
+          type: "SET_DISSOLVE_TIMESTAMP",
+          account: src_account,
+          metadata: {
+            neuron_index: neuron_idx,
+            dissolve_time_utc_seconds: dissolve_time_utc_seconds,
+          },
+        },
+      ],
+      metadata: opts,
+      public_keys: [src_pub_key_obj],
+    });
+
+    const submit_res = await this.combine_submit(src_key, payloads_res);
+
+    return submit_res;
+  }
+
+  async neuron_start_dissolving(src_key, neuron_idx, opts = {}) {
+    const net_id = await this.network_identifier;
+
+    const src_pub_key = key_to_pub_key(src_key);
+    const src_account = {
+      address: address_to_hex(pub_key_to_address(src_pub_key)),
+    };
+    const src_pub_key_obj = {
+      hex_bytes: blobToHex(src_pub_key),
+      curve_type: "edwards25519",
+    };
+
+    const payloads_res = await this.payloads({
+      network_identifier: net_id,
+      operations: [
+        {
+          operation_identifier: { index: 0 },
+          type: "START_DISSOLVING",
+          account: src_account,
+          metadata: {
+            neuron_index: neuron_idx,
+          },
+        },
+      ],
+      metadata: opts,
+      public_keys: [src_pub_key_obj],
+    });
+
+    const submit_res = await this.combine_submit(src_key, payloads_res);
+
+    return submit_res;
+  }
+
+  async neuron_stop_dissolving(src_key, neuron_idx, opts = {}) {
+    const net_id = await this.network_identifier;
+
+    const src_pub_key = key_to_pub_key(src_key);
+    const src_account = {
+      address: address_to_hex(pub_key_to_address(src_pub_key)),
+    };
+    const src_pub_key_obj = {
+      hex_bytes: blobToHex(src_pub_key),
+      curve_type: "edwards25519",
+    };
+
+    const payloads_res = await this.payloads({
+      network_identifier: net_id,
+      operations: [
+        {
+          operation_identifier: { index: 0 },
+          type: "STOP_DISSOLVING",
+          account: src_account,
+          metadata: {
+            neuron_index: neuron_idx,
+          },
+        },
+      ],
+      metadata: opts,
+      public_keys: [src_pub_key_obj],
+    });
+
+    const submit_res = await this.combine_submit(src_key, payloads_res);
+
+    return submit_res;
+  }
+
+  async neuron_disburse(src_key, neuron_idx, dest_addr, count, opts = {}) {
+    const net_id = await this.network_identifier;
+    const currency = await this.currency;
+
+    const src_pub_key = key_to_pub_key(src_key);
+    const src_addr = pub_key_to_address(src_pub_key);
+    const src_account = {
+      address: address_to_hex(src_addr),
+    };
+    const src_pub_key_obj = {
+      hex_bytes: blobToHex(src_pub_key),
+      curve_type: "edwards25519",
+    };
+
+    if (!dest_addr) dest_addr = src_addr;
+
+    const amount_obj = count
+      ? {
+          amount: {
+            value: `${count}`,
+            currency: currency,
+          },
+        }
+      : {};
+
+    const payloads_res = await this.payloads({
+      network_identifier: net_id,
+      operations: [
+        {
+          operation_identifier: { index: 0 },
+          type: "DISBURSE",
+          account: src_account,
+          metadata: Object.assign(
+            {
+              neuron_index: neuron_idx,
+              recipient: address_to_hex(dest_addr),
+            },
+            amount_obj
+          ),
+        },
+      ],
+      metadata: opts,
+      public_keys: [src_pub_key_obj],
+    });
+
+    const submit_res = await this.combine_submit(src_key, payloads_res);
 
     return submit_res;
   }

--- a/lib/session.js
+++ b/lib/session.js
@@ -5,7 +5,6 @@ const {
   key_sign,
   key_to_pub_key,
   pub_key_to_address,
-  pub_key_to_principal_id,
   address_from_hex,
   address_to_hex,
 } = require("./key");
@@ -345,6 +344,10 @@ class Session {
     };
 
     if (!src_pub_key) src_pub_key = hot_pub_key;
+    const src_pub_key_obj = {
+      hex_bytes: blobToHex(src_pub_key),
+      curve_type: "edwards25519",
+    };
     const src_account = {
       address: address_to_hex(pub_key_to_address(src_pub_key)),
     };
@@ -358,7 +361,7 @@ class Session {
           account: src_account,
           metadata: {
             neuron_index: neuron_idx,
-            controller: pub_key_to_principal_id(src_pub_key),
+            controller: { public_key: src_pub_key_obj },
           },
         },
       ],

--- a/lib/session.js
+++ b/lib/session.js
@@ -604,6 +604,50 @@ class Session {
 
     return submit_res;
   }
+
+  async neuron_follow(
+    hot_key,
+    neuron_idx,
+    src_pub_key,
+    followees,
+    topic,
+    opts = {}
+  ) {
+    const net_id = await this.network_identifier;
+
+    const hot_pub_key = key_to_pub_key(hot_key);
+    const hot_pub_key_obj = {
+      hex_bytes: blobToHex(hot_pub_key),
+      curve_type: "edwards25519",
+    };
+
+    if (!src_pub_key) src_pub_key = hot_pub_key;
+    const src_account = {
+      address: address_to_hex(pub_key_to_address(src_pub_key)),
+    };
+
+    const payloads_res = await this.payloads({
+      network_identifier: net_id,
+      operations: [
+        {
+          operation_identifier: { index: 0 },
+          type: "FOLLOW",
+          account: src_account,
+          metadata: {
+            topic: topic,
+            followees: followees,
+            neuron_index: neuron_idx,
+          },
+        },
+      ],
+      metadata: opts,
+      public_keys: [hot_pub_key_obj],
+    });
+
+    const submit_res = await this.combine_submit(hot_key, payloads_res);
+
+    return submit_res;
+  }
 }
 
 exports.Session = Session;

--- a/lib/session.js
+++ b/lib/session.js
@@ -739,6 +739,84 @@ class Session {
 
     return submit_res;
   }
+
+  async neuron_add_hotkey(src_key, neuron_idx, hot_pub_key, opts = {}) {
+    const net_id = await this.network_identifier;
+
+    const hot_pub_key_obj = {
+      hex_bytes: blobToHex(hot_pub_key),
+      curve_type: "edwards25519",
+    };
+
+    const src_pub_key = key_to_pub_key(src_key);
+    const src_pub_key_obj = {
+      hex_bytes: blobToHex(src_pub_key),
+      curve_type: "edwards25519",
+    };
+    const src_account = {
+      address: address_to_hex(pub_key_to_address(src_pub_key)),
+    };
+
+    const payloads_res = await this.payloads({
+      network_identifier: net_id,
+      operations: [
+        {
+          operation_identifier: { index: 0 },
+          type: "ADD_HOTKEY",
+          account: src_account,
+          metadata: {
+            neuron_index: neuron_idx,
+            public_key: hot_pub_key_obj,
+          },
+        },
+      ],
+      metadata: opts,
+      public_keys: [src_pub_key_obj],
+    });
+
+    const submit_res = await this.combine_submit(src_key, payloads_res);
+
+    return submit_res;
+  }
+
+  async neuron_remove_hotkey(src_key, neuron_idx, hot_pub_key, opts = {}) {
+    const net_id = await this.network_identifier;
+
+    const hot_pub_key_obj = {
+      hex_bytes: blobToHex(hot_pub_key),
+      curve_type: "edwards25519",
+    };
+
+    const src_pub_key = key_to_pub_key(src_key);
+    const src_pub_key_obj = {
+      hex_bytes: blobToHex(src_pub_key),
+      curve_type: "edwards25519",
+    };
+    const src_account = {
+      address: address_to_hex(pub_key_to_address(src_pub_key)),
+    };
+
+    const payloads_res = await this.payloads({
+      network_identifier: net_id,
+      operations: [
+        {
+          operation_identifier: { index: 0 },
+          type: "REMOVE_HOTKEY",
+          account: src_account,
+          metadata: {
+            neuron_index: neuron_idx,
+            public_key: hot_pub_key_obj,
+          },
+        },
+      ],
+      metadata: opts,
+      public_keys: [src_pub_key_obj],
+    });
+
+    const submit_res = await this.combine_submit(src_key, payloads_res);
+
+    return submit_res;
+  }
 }
 
 exports.Session = Session;

--- a/lib/session.js
+++ b/lib/session.js
@@ -489,6 +489,13 @@ class Session {
     return submit_res;
   }
 
+  /**
+   *
+   * @param {Buffer} src_key
+   * @param {bigint} neuron_idx
+   * @param {object?} opts
+   * @returns {Promise<TransactionIdentifierResponse>}
+   */
   async neuron_start_dissolving(src_key, neuron_idx, opts = {}) {
     const net_id = await this.network_identifier;
 
@@ -522,6 +529,13 @@ class Session {
     return submit_res;
   }
 
+  /**
+   *
+   * @param {Buffer} src_key
+   * @param {bigint} neuron_idx
+   * @param {object?} opts
+   * @returns {Promise<TransactionIdentifierResponse>}
+   */
   async neuron_stop_dissolving(src_key, neuron_idx, opts = {}) {
     const net_id = await this.network_identifier;
 
@@ -555,6 +569,15 @@ class Session {
     return submit_res;
   }
 
+  /**
+   *
+   * @param {Buffer} src_key
+   * @param {bigint} neuron_idx
+   * @param {Buffer?} dest_addr
+   * @param {bigint?} count
+   * @param {object?} opts
+   * @returns {Promise<TransactionIdentifierResponse>}
+   */
   async neuron_disburse(src_key, neuron_idx, dest_addr, count, opts = {}) {
     const net_id = await this.network_identifier;
     const currency = await this.currency;
@@ -605,6 +628,16 @@ class Session {
     return submit_res;
   }
 
+  /**
+   *
+   * @param {Buffer} hot_key
+   * @param {bigint} neuron_idx
+   * @param {Buffer?} src_pub_key
+   * @param {Array<bigint>} followees
+   * @param {number} topic
+   * @param {object?} opts
+   * @returns {Promise<TransactionIdentifierResponse>}
+   */
   async neuron_follow(
     hot_key,
     neuron_idx,
@@ -654,6 +687,15 @@ class Session {
     return submit_res;
   }
 
+  /**
+   *
+   * @param {Buffer} src_key
+   * @param {bigint} neuron_idx
+   * @param {Buffer?} spawned_neuron_pub_key
+   * @param {bigint} spawned_neuron_idx
+   * @param {object?} opts
+   * @returns {Promise<TransactionIdentifierResponse>}
+   */
   async neuron_spawn(
     src_key,
     neuron_idx,
@@ -701,6 +743,14 @@ class Session {
     return submit_res;
   }
 
+  /**
+   *
+   * @param {Buffer} src_key
+   * @param {bigint} neuron_idx
+   * @param {number?} percentage_to_merge
+   * @param {object?} opts
+   * @returns {Promise<TransactionIdentifierResponse>}
+   */
   async neuron_merge(
     src_key,
     neuron_idx,
@@ -740,6 +790,14 @@ class Session {
     return submit_res;
   }
 
+  /**
+   *
+   * @param {Buffer} src_key
+   * @param {bigint} neuron_idx
+   * @param {Buffer} hot_pub_key
+   * @param {object?} opts
+   * @returns {Promise<TransactionIdentifierResponse>}
+   */
   async neuron_add_hotkey(src_key, neuron_idx, hot_pub_key, opts = {}) {
     const net_id = await this.network_identifier;
 
@@ -779,6 +837,14 @@ class Session {
     return submit_res;
   }
 
+  /**
+   *
+   * @param {Buffer} src_key
+   * @param {bigint} neuron_idx
+   * @param {Buffer} hot_pub_key
+   * @param {object?} opts
+   * @returns {Promise<TransactionIdentifierResponse>}
+   */
   async neuron_remove_hotkey(src_key, neuron_idx, hot_pub_key, opts = {}) {
     const net_id = await this.network_identifier;
 

--- a/test/neurons.csv
+++ b/test/neurons.csv
@@ -1,0 +1,2 @@
+neuron_id;owner_id;created_ts_ns;duration_to_dissolution_ns;staked_icpt;earnings;follows;not_for_profit;memo;maturity_e8s_equivalent;kyc_verified
+114514;hchtx-aevdv-xxhz5-vbltd-a3qg3-47ysz-4txvz-biecj-4swt2-6ikkq-yae;1;1;10000000000;D;;false;1919810;1145141919810;true

--- a/test/test-staking-merge-spawn.js
+++ b/test/test-staking-merge-spawn.js
@@ -1,0 +1,43 @@
+const JSONbig = require("json-bigint")({ strict: true, useNativeBigInt: true });
+const fs = require("fs");
+const { key_new, seed_from_pem, Session } = require("../dist/main");
+
+(async () => {
+  const session = new Session({ baseUrl: "http://127.0.0.1:8080" });
+
+  try {
+    const src_key = key_new(
+      seed_from_pem(fs.readFileSync("identity/initial/identity.pem"))
+    );
+
+    const neuron_idx = 1919810n;
+
+    res = await session.neuron_protected_info(src_key, neuron_idx);
+    console.log(JSONbig.stringify(res, null, 2));
+
+    res = await session.neuron_merge(src_key, neuron_idx, 50);
+    console.log(JSONbig.stringify(res, null, 2));
+
+    res = await session.neuron_protected_info(src_key, neuron_idx);
+    console.log(JSONbig.stringify(res, null, 2));
+
+    const spawned_neuron_idx = 365n;
+
+    res = await session.neuron_spawn(
+      src_key,
+      neuron_idx,
+      null,
+      spawned_neuron_idx
+    );
+    console.log(JSONbig.stringify(res, null, 2));
+
+    res = await session.neuron_protected_info(src_key, spawned_neuron_idx);
+    console.log(JSONbig.stringify(res, null, 2));
+
+    res = await session.neuron_disburse(src_key, neuron_idx);
+    console.log(JSONbig.stringify(res, null, 2));
+  } catch (err) {
+    console.error(JSONbig.stringify(err.response.data, null, 2));
+    throw new Error();
+  }
+})();

--- a/test/test-staking.js
+++ b/test/test-staking.js
@@ -1,0 +1,62 @@
+const JSONbig = require("json-bigint")({ strict: true, useNativeBigInt: true });
+const fs = require("fs");
+const { performance } = require("perf_hooks");
+const { key_new, seed_from_pem, Session } = require("../dist/main");
+const crypto = require("crypto");
+
+function seconds_since_unix_epoch() {
+  return BigInt(
+    Math.round((performance.timeOrigin + performance.now()) / 1000)
+  );
+}
+
+async function sleep(secs) {
+  await new Promise((resolve) => {
+    setTimeout(resolve, secs * 1000);
+  });
+}
+
+(async () => {
+  const session = new Session({ baseUrl: "http://127.0.0.1:8080" });
+
+  try {
+    const src_key = key_new(
+      seed_from_pem(fs.readFileSync("identity/initial/identity.pem"))
+    );
+
+    const neuron_idx = BigInt(crypto.randomInt(2 ** 48 - 1));
+
+    let res = await session.neuron_charge(src_key, neuron_idx, 100000000n);
+    console.log(JSONbig.stringify(res, null, 2));
+
+    res = await session.neuron_stake(src_key, neuron_idx);
+    console.log(JSONbig.stringify(res, null, 2));
+
+    res = await session.neuron_set_dissolve_timestamp(
+      src_key,
+      neuron_idx,
+      seconds_since_unix_epoch() + 4n
+    );
+    console.log(JSONbig.stringify(res, null, 2));
+
+    res = await session.neuron_protected_info(src_key, neuron_idx);
+    console.log(JSONbig.stringify(res, null, 2));
+
+    res = await session.neuron_start_dissolving(src_key, neuron_idx);
+    console.log(JSONbig.stringify(res, null, 2));
+
+    await sleep(8);
+
+    res = await session.neuron_protected_info(src_key, neuron_idx);
+    console.log(JSONbig.stringify(res, null, 2));
+
+    res = await session.neuron_disburse(src_key, neuron_idx);
+    console.log(JSONbig.stringify(res, null, 2));
+
+    res = await session.neuron_protected_info(src_key, neuron_idx);
+    console.log(JSONbig.stringify(res, null, 2));
+  } catch (err) {
+    console.error(JSONbig.stringify(err.response.data, null, 2));
+    throw err;
+  }
+})();

--- a/test/test-staking.js
+++ b/test/test-staking.js
@@ -1,8 +1,14 @@
 const JSONbig = require("json-bigint")({ strict: true, useNativeBigInt: true });
 const fs = require("fs");
 const { performance } = require("perf_hooks");
-const { key_new, seed_from_pem, Session } = require("../dist/main");
+const {
+  key_new,
+  key_to_pub_key,
+  seed_from_pem,
+  Session,
+} = require("../dist/main");
 const crypto = require("crypto");
+const util = require("util");
 
 function seconds_since_unix_epoch() {
   return BigInt(
@@ -66,8 +72,18 @@ async function sleep(secs) {
 
     res = await session.neuron_protected_info(src_key, neuron_idx);
     console.log(JSONbig.stringify(res, null, 2));
+
+    const hot_pub_key = key_to_pub_key(
+      key_new(await util.promisify(crypto.randomBytes)(32))
+    );
+
+    res = await session.neuron_add_hotkey(src_key, neuron_idx, hot_pub_key);
+    console.log(JSONbig.stringify(res, null, 2));
+
+    res = await session.neuron_remove_hotkey(src_key, neuron_idx, hot_pub_key);
+    console.log(JSONbig.stringify(res, null, 2));
   } catch (err) {
     console.error(JSONbig.stringify(err.response.data, null, 2));
-    throw new Error();
+    throw new Error(err.response.data);
   }
 })();

--- a/test/test-staking.js
+++ b/test/test-staking.js
@@ -67,7 +67,7 @@ async function sleep(secs) {
     res = await session.neuron_protected_info(src_key, neuron_idx);
     console.log(JSONbig.stringify(res, null, 2));
 
-    res = await session.neuron_disburse(src_key, neuron_idx);
+    res = await session.neuron_disburse(src_key, neuron_idx, null, 1n);
     console.log(JSONbig.stringify(res, null, 2));
 
     res = await session.neuron_protected_info(src_key, neuron_idx);

--- a/test/test-staking.js
+++ b/test/test-staking.js
@@ -42,6 +42,17 @@ async function sleep(secs) {
     res = await session.neuron_protected_info(src_key, neuron_idx);
     console.log(JSONbig.stringify(res, null, 2));
 
+    const neuron_id = BigInt(res.metadata.operations[0].metadata.neuron_id);
+
+    res = await session.neuron_follow(
+      src_key,
+      neuron_idx,
+      null,
+      [neuron_id],
+      0
+    );
+    console.log(JSONbig.stringify(res, null, 2));
+
     res = await session.neuron_start_dissolving(src_key, neuron_idx);
     console.log(JSONbig.stringify(res, null, 2));
 

--- a/test/test-staking.js
+++ b/test/test-staking.js
@@ -68,6 +68,6 @@ async function sleep(secs) {
     console.log(JSONbig.stringify(res, null, 2));
   } catch (err) {
     console.error(JSONbig.stringify(err.response.data, null, 2));
-    throw err;
+    throw new Error();
   }
 })();


### PR DESCRIPTION
- All rosetta operations related to staking are implemented, e2e tested and documented.
- E2E testing now includes test neurons, so we can test merge & spawn operations directly.
- Don't use dfx for e2e testing, call `ic-starter` to set up the replica directly, which comes from the ic blessed artifacts.
- Fix protobuf autogen files, also aligns protoc version with current ic build image